### PR TITLE
Removes trailing slash on resource, if present

### DIFF
--- a/fcrepo-export/src/main/java/org/fcrepo/exporter/Config.java
+++ b/fcrepo-export/src/main/java/org/fcrepo/exporter/Config.java
@@ -108,14 +108,23 @@ public class Config {
      * Sets the URI of the resource to import/export
      */
     public void setResource(final String resource) throws URISyntaxException {
-        this.resource = new URI(resource);
+        if (resource != null && (resource.lastIndexOf('/') == resource.length() - 1)) {
+          this.resource = new URI(resource.substring(0, resource.length() - 1));
+        } else {
+          this.resource = new URI(resource);
+        }
     }
 
     /**
      * Sets the URI of the resource to import/export
      */
-    public void setResource(final URI resource) {
-        this.resource = resource;
+    public void setResource(final URI resource) throws URISyntaxException {
+        if (resource.toString().lastIndexOf('/') == resource.toString().length() - 1) {
+            this.resource = new URI(
+                resource.toString().substring(0, resource.toString().length() - 1));
+        } else {
+            this.resource = resource;
+        }
     }
 
     /**

--- a/fcrepo-export/src/main/java/org/fcrepo/exporter/Config.java
+++ b/fcrepo-export/src/main/java/org/fcrepo/exporter/Config.java
@@ -108,18 +108,14 @@ public class Config {
      * Sets the URI of the resource to import/export
      */
     public void setResource(final String resource) throws URISyntaxException {
-        if (resource != null && (resource.lastIndexOf('/') == resource.length() - 1)) {
-          this.resource = new URI(resource.substring(0, resource.length() - 1));
-        } else {
-          this.resource = new URI(resource);
-        }
+        setResource(new URI(resource));
     }
 
     /**
      * Sets the URI of the resource to import/export
      */
     public void setResource(final URI resource) throws URISyntaxException {
-        if (resource.toString().lastIndexOf('/') == resource.toString().length() - 1) {
+        if (resource.toString().endsWith("/")) {
             this.resource = new URI(
                 resource.toString().substring(0, resource.toString().length() - 1));
         } else {


### PR DESCRIPTION
-Added code to remove a trailing slash if one is present on the
URI of the resource that the user requested to export.

Resolves: https://jira.durspace.org/browse/FCREPO-2149