### PR TITLE
Creates dynamic ajp port for tomcat tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <configuration>
           <portNames>
             <portName>fcrepo.dynamic.test.port</portName>
+            <portName>fcrepo.dynamic.tomcat.ajp.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -122,6 +123,7 @@
             <fcrepo.executable.jar>${project.build.directory}/${project.artifactId}-${project.version}.jar</fcrepo.executable.jar>
             <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
             <project.build.directory>${project.build.directory}</project.build.directory>
+            <fcrepo.dynamic.tomcat.ajp.port>${fcrepo.dynamic.tomcat.ajp.port}</fcrepo.dynamic.tomcat.ajp.port>
           </systemPropertyVariables>
         </configuration>
         <executions>
@@ -251,6 +253,7 @@
           <configuration>
             <properties>
               <cargo.servlet.port>${fcrepo.dynamic.test.port}</cargo.servlet.port>
+              <cargo.tomcat.ajp.port>${fcrepo.dynamic.tomcat.ajp.port}</cargo.tomcat.ajp.port>
             </properties>
             <files>
               <copy>


### PR DESCRIPTION
Adds a dynamic port for the tomcat ajp port.  This will prevent
a collision if a tomcat server is already running on the machine.

Resolves: https://jira.duraspace.org/browse/FCREPO-2211