### PR TITLE
Adding integration tests to demonstrate roundtripping containers and binaries

### DIFF
--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -25,21 +25,21 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.sparql.core.DatasetImpl;
 import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoHttpClientBuilder;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 import org.junit.Before;
 import org.slf4j.Logger;
 
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.apache.jena.graph.Node.ANY;
-import static org.apache.jena.graph.NodeFactory.createLiteral;
-import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.http.HttpStatus.SC_GONE;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.apache.jena.rdf.model.ResourceFactory.createPlainLiteral;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.riot.RDFDataMgr.loadModel;
+import static org.apache.jena.riot.web.HttpOp.setDefaultHttpClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -56,7 +56,27 @@ abstract class AbstractResourceIT {
 
     private static final String HOSTNAME = "localhost";
 
+    static final String DC_DATE = "http://purl.org/dc/elements/1.1/date";
+    static final String DC_RELATION = "http://purl.org/dc/elements/1.1/relation";
     static final String DC_TITLE = "http://purl.org/dc/elements/1.1/title";
+    static final String DCTERMS_HAS_PART = "http://purl.org/dc/terms/hasPart";
+    static final String EBU_HAS_MIME_TYPE = "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType";
+    static final String EDM_BEGIN = "http://www.europeana.eu/schemas/edm/begin";
+    static final String EDM_END = "http://www.europeana.eu/schemas/edm/end";
+    static final String EDM_TIMESPAN = "http://www.europeana.eu/schemas/edm/TimeSpan";
+    static final String LDP_DIRECT_CONTAINER = "http://www.w3.org/ns/ldp#DirectContainer";
+    static final String LDP_HAS_MEMBER_RELATION = "http://www.w3.org/ns/ldp#hasMemberRelation";
+    static final String LDP_INDIRECT_CONTAINER = "http://www.w3.org/ns/ldp#IndirectContainer";
+    static final String LDP_INSERTED_CONTENT_RELATION = "http://www.w3.org/ns/ldp#insertedContentRelation";
+    static final String LDP_MEMBERSHIP_RESOURCE = "http://www.w3.org/ns/ldp#membershipResource";
+    static final String LDP_NON_RDF_SOURCE = "http://www.w3.org/ns/ldp#NonRDFSource";
+    static final String ORE_PROXY = "http://www.openarchives.org/ore/terms/Proxy";
+    static final String ORE_PROXY_FOR = "http://www.openarchives.org/ore/terms/proxyFor";
+    static final String PCDM_OBJECT = "http://pcdm.org/models#Object";
+    static final String PREMIS_SIZE = "http://www.loc.gov/premis/rdf/v1#hasSize";
+    static final String PREMIS_DIGEST = "http://www.loc.gov/premis/rdf/v1#hasMessageDigest";
+    static final String SKOS_PREFLABEL = "http://www.w3.org/2004/02/skos/core#prefLabel";
+    static final String XSD_DATETIME = "http://www.w3.org/2001/XMLSchema#dateTime";
 
     static final String USERNAME = "fedoraAdmin";
 
@@ -70,6 +90,7 @@ abstract class AbstractResourceIT {
 
     AbstractResourceIT() {
         clientBuilder = FcrepoClient.client().credentials(USERNAME, PASSWORD).authScope("localhost");
+        setDefaultHttpClient(new FcrepoHttpClientBuilder(USERNAME, PASSWORD, "localhost").build());
 
         final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         connectionManager.setMaxTotal(Integer.MAX_VALUE);
@@ -84,8 +105,20 @@ abstract class AbstractResourceIT {
     }
 
     protected FcrepoResponse create(final URI uri) throws FcrepoOperationFailedException {
-        logger.debug("Request ------: {}", uri);
+        logger.debug("Create ---------: {}", uri);
         return clientBuilder.build().put(uri).perform();
+    }
+
+    protected FcrepoResponse createBody(final URI uri, final String body, final String contentType)
+            throws FcrepoOperationFailedException {
+        logger.debug("Create with binary: {}", uri);
+        final InputStream stream = new ByteArrayInputStream(body.getBytes());
+        return clientBuilder.build().put(uri).body(stream, contentType).perform();
+    }
+
+    protected FcrepoResponse createTurtle(final URI uri, final String body)
+            throws FcrepoOperationFailedException {
+        return createBody(uri, body, "text/turtle");
     }
 
     protected InputStream insertTitle(final String title) {
@@ -98,15 +131,34 @@ abstract class AbstractResourceIT {
         }
     }
 
-    protected void assertHasTitle(final URI url, final String title) throws FcrepoOperationFailedException {
-        final FcrepoResponse getResponse = clientBuilder.build().get(url).accept("application/n-triples").perform();
-        assertEquals("GET of " + url + " failed!", SC_OK, getResponse.getStatusCode());
-        final Model model = createDefaultModel();
-        final Dataset d = new DatasetImpl(model.read(getResponse.getBody(), "", "application/n-triples"));
+    protected FcrepoResponse patch(final URI uri, final String command) throws FcrepoOperationFailedException {
+        logger.debug("Patch: {}", uri);
+        final InputStream stream = new ByteArrayInputStream(command.getBytes());
+        return clientBuilder.build().patch(uri).body(stream).perform();
+    }
 
-        assertTrue(url + " should have had the dc:title, \"" + title + "\"!",
-                d.asDatasetGraph().contains(ANY, createURI(url.toString()),
-                        createProperty(DC_TITLE).asNode(), createLiteral(title)));
+    protected boolean exists(final URI uri) throws FcrepoOperationFailedException {
+        final FcrepoResponse resp = clientBuilder.build().head(uri).disableRedirects().perform();
+        return resp.getStatusCode() == 200 || resp.getStatusCode() == 307;
+    }
+
+    protected Model getAsModel(final URI uri) throws FcrepoOperationFailedException {
+        return loadModel(uri.toString());
+    }
+
+    protected void assertHasTitle(final URI uri, final String title) throws FcrepoOperationFailedException {
+        final Model model = getAsModel(uri);
+        assertTrue(uri + " should have had the dc:title, \"" + title + "\"!",
+                model.contains(createResource(uri.toString()), createProperty(DC_TITLE), createPlainLiteral(title)));
+    }
+
+    protected void removeAndReset(final URI uri) throws FcrepoOperationFailedException {
+        clientBuilder.build().delete(uri).perform();
+        final FcrepoResponse getResponse = clientBuilder.build().get(uri).perform();
+        assertEquals("Resource should have been deleted!", SC_GONE, getResponse.getStatusCode());
+        final URI tombstone = getResponse.getLinkHeaders("hasTombstone").get(0);
+        final FcrepoResponse delResponse = clientBuilder.build().delete(tombstone).perform();
+        assertEquals("Failed to delete the tombstone!", SC_NO_CONTENT, delResponse.getStatusCode());
     }
 
     abstract protected Logger logger();

--- a/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
@@ -37,7 +37,6 @@ import java.net.URI;
 import java.util.UUID;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
-import static org.apache.http.HttpStatus.SC_GONE;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_EXT;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_LANG;
@@ -93,11 +92,7 @@ public class ImporterIT extends AbstractResourceIT {
         resourceExists(parent);
 
         // Remove the resources
-        client.delete(parent).perform();
-        final FcrepoResponse getResponse = client.get(parent).perform();
-        assertEquals("Resource should have been deleted!", SC_GONE, getResponse.getStatusCode());
-        assertEquals("Failed to delete the tombstone!", SC_NO_CONTENT,
-                client.delete(getResponse.getLinkHeaders("hasTombstone").get(0)).perform().getStatusCode());
+        removeAndReset(parent);
 
         // Run the import process
         config.setMode("import");

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.integration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URI;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.importexport.common.Config;
+import org.fcrepo.importexport.exporter.Exporter;
+import org.fcrepo.importexport.importer.Importer;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong;
+import static org.apache.jena.rdf.model.ResourceFactory.createLangLiteral;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
+import static org.apache.jena.riot.RDFDataMgr.loadModel;
+import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_EXT;
+import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_LANG;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
+import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author escowles
+ * @since 2016-12-07
+ */
+public class RoundtripIT extends AbstractResourceIT {
+
+    private FcrepoClient client;
+
+    public RoundtripIT() {
+        super();
+        client = clientBuilder.build();
+    }
+
+    @Test
+    public void testRoundtripMinimal() throws Exception {
+        final URI uri = URI.create(serverAddress + UUID.randomUUID());
+        final FcrepoResponse response = create(uri);
+        assertEquals(SC_CREATED, response.getStatusCode());
+        assertEquals(uri, response.getLocation());
+        create(URI.create(uri.toString() + "/res1"));
+
+        roundtrip(uri);
+
+        final Model model = getAsModel(URI.create(uri.toString() + "/res1"));
+        assertTrue(model.contains(null, RDF_TYPE, CONTAINER));
+    }
+
+    @Test
+    public void testRoundtripMetadata() throws Exception {
+        final UUID uuid = UUID.randomUUID();
+        final String baseURI = serverAddress + uuid;
+        final URI res1 = URI.create(baseURI + "/res1");
+        final URI res2 = URI.create(baseURI + "/res2");
+
+        final Resource subject = createResource(res2.toString());
+        final Resource date1 = createResource(res2.toString() + "#date1");
+
+        create(res1);
+
+        final String turtle = "<> a <" + PCDM_OBJECT + "> ; "
+            + "<" + DC_TITLE + "> \"metadata test\" ; "
+            + "<" + DC_TITLE + "> \"metadata test\"@en ; "
+            + "<" + DC_RELATION + "> <" + res1.toString() + "> ; "
+            + "<" + DC_DATE + "> <#date1> . "
+            + "<#date1> a <" + EDM_TIMESPAN + "> ; "
+            + "<" + SKOS_PREFLABEL + "> \"The last 20 seconds of 2013\" ; "
+            + "<" + EDM_BEGIN + "> \"2013-12-31T23:59:39Z\"^^<" + XSD_DATETIME + "> ; "
+            + "<" + EDM_END + "> \"2013-12-31T23:59:59Z\"^^<" + XSD_DATETIME + "> . ";
+        createTurtle(res2, turtle);
+
+        final Config config = roundtrip(URI.create(baseURI));
+
+        // verify that files exist and contain expected content
+        final File exportDir = config.getBaseDirectory();
+        final File res2File = new File(exportDir, "fcrepo/rest/" + uuid + "/res2" + config.getRdfExtension());
+
+        assertTrue(res2File.exists() && res2File.isFile());
+        final Model res2Model = loadModel(res2File.getAbsolutePath());
+        assertTrue(res2Model.contains(subject, RDF_TYPE, CONTAINER));
+        assertTrue(res2Model.contains(subject, RDF_TYPE, createResource(PCDM_OBJECT)));
+        assertTrue(res2Model.contains(subject, createProperty(DC_TITLE), "metadata test"));
+        assertTrue(res2Model.contains(subject, createProperty(DC_TITLE), createLangLiteral("metadata test","en")));
+        assertTrue(res2Model.contains(subject, createProperty(DC_RELATION), createResource(res1.toString())));
+        assertTrue(res2Model.contains(subject, createProperty(DC_DATE), date1));
+        assertTrue(res2Model.contains(date1, RDF_TYPE, createResource(EDM_TIMESPAN)));
+        assertTrue(res2Model.contains(date1, createProperty(EDM_BEGIN), dateLiteral("2013-12-31T23:59:39Z")));
+        assertTrue(res2Model.contains(date1, createProperty(EDM_END), dateLiteral("2013-12-31T23:59:59Z")));
+
+        // verify metadata in the repository
+        assertTrue(exists(res1));
+        final Model model = getAsModel(res2);
+        assertTrue(model.contains(subject, RDF_TYPE, CONTAINER));
+        assertTrue(model.contains(subject, RDF_TYPE, createResource(PCDM_OBJECT)));
+        assertTrue(model.contains(subject, createProperty(DC_TITLE), "metadata test"));
+        assertTrue(model.contains(subject, createProperty(DC_TITLE), createLangLiteral("metadata test","en")));
+        assertTrue(model.contains(subject, createProperty(DC_RELATION), createResource(res1.toString())));
+        assertTrue(model.contains(subject, createProperty(DC_DATE), date1));
+        assertTrue(model.contains(date1, RDF_TYPE, createResource(EDM_TIMESPAN)));
+        assertTrue(model.contains(date1, createProperty(EDM_BEGIN), dateLiteral("2013-12-31T23:59:39Z")));
+        assertTrue(model.contains(date1, createProperty(EDM_END), dateLiteral("2013-12-31T23:59:59Z")));
+    }
+
+    @Test
+    public void testRoundtripDirectContainer() throws Exception {
+        final String baseURI = serverAddress + UUID.randomUUID();
+        final URI res1 = URI.create(baseURI + "/res1");
+        final URI parts = URI.create(baseURI + "/res1/parts");
+        final URI part1 = URI.create(baseURI + "/res1/parts/part1");
+
+
+        final String partsTurtle = "<> a <" + LDP_DIRECT_CONTAINER + "> ; "
+            + "<" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
+            + "<" + LDP_MEMBERSHIP_RESOURCE + "> <" +  res1.toString() + "> .";
+
+        create(res1);
+        createTurtle(parts, partsTurtle);
+        create(part1);
+
+        roundtrip(URI.create(baseURI));
+
+        final Resource parent = createResource(res1.toString());
+        final Resource container = createResource(parts.toString());
+        final Resource member = createResource(part1.toString());
+
+        final Model model1 = getAsModel(res1);
+        assertTrue(model1.contains(parent, createProperty(DCTERMS_HAS_PART), member));
+
+        final Model model2 = getAsModel(parts);
+        assertTrue(model2.contains(container, RDF_TYPE, createResource(LDP_DIRECT_CONTAINER)));
+        assertTrue(model2.contains(container, createProperty(LDP_HAS_MEMBER_RELATION),
+                createResource(DCTERMS_HAS_PART)));
+        assertTrue(model2.contains(container, createProperty(LDP_MEMBERSHIP_RESOURCE), parent));
+
+        // make sure membership triples were generated by the container
+        client.delete(part1).perform();
+        final Model model3 = getAsModel(res1);
+        assertFalse(model3.contains(parent, createProperty(DCTERMS_HAS_PART), member));
+    }
+
+    @Test
+    public void testRoundtripIndirectContainer() throws Exception {
+        final String baseURI = serverAddress + UUID.randomUUID();
+        final URI res1 = URI.create(baseURI + "/res1");
+        final URI res2 = URI.create(baseURI + "/res2");
+        final URI parts = URI.create(baseURI + "/res2/parts");
+        final URI proxy = URI.create(baseURI + "/res2/parts/proxy1");
+
+        final String partsTurtle = "<> a <" + LDP_INDIRECT_CONTAINER + "> ; "
+            + "<" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
+            + "<" + LDP_MEMBERSHIP_RESOURCE + "> <" +  res2.toString() + "> ; "
+            + "<" + LDP_INSERTED_CONTENT_RELATION + "> <" + ORE_PROXY_FOR + "> .";
+
+        final String proxyTurtle = "<> a <" + ORE_PROXY + "> ; "
+            + "<" + ORE_PROXY_FOR + "> <" + res1.toString() + "> . ";
+
+        create(res1);
+        create(res2);
+        createTurtle(parts, partsTurtle);
+        createTurtle(proxy, proxyTurtle);
+
+        roundtrip(URI.create(baseURI));
+
+        final Resource member = createResource(res1.toString());
+        final Resource parent = createResource(res2.toString());
+        final Resource container = createResource(parts.toString());
+
+        final Model model1 = getAsModel(res2);
+        assertTrue(model1.contains(parent, createProperty(DCTERMS_HAS_PART), member));
+
+        final Model model2 = getAsModel(parts);
+        assertTrue(model2.contains(container, RDF_TYPE, createResource(LDP_INDIRECT_CONTAINER)));
+        assertTrue(model2.contains(container, createProperty(LDP_HAS_MEMBER_RELATION),
+                createResource(DCTERMS_HAS_PART)));
+        assertTrue(model2.contains(container, createProperty(LDP_MEMBERSHIP_RESOURCE), parent));
+        assertTrue(model2.contains(container, createProperty(LDP_INSERTED_CONTENT_RELATION),
+                createResource(ORE_PROXY_FOR)));
+
+        // make sure membership triples were generated by the container
+        client.delete(proxy).perform();
+        final Model model3 = getAsModel(res2);
+        assertFalse(model3.contains(parent, createProperty(DCTERMS_HAS_PART), member));
+    }
+
+    @Test
+    public void testRoundtripBinaries() throws Exception {
+        final UUID uuid = UUID.randomUUID();
+        final String baseURI = serverAddress + uuid;
+        final URI res1 = URI.create(baseURI);
+        final URI file1 = URI.create(baseURI + "/file1");
+
+        final Resource container = createResource(res1.toString());
+        final Resource binary = createResource(file1.toString());
+
+        final String file1patch = "insert data { "
+            + "<" + file1.toString() + "> <" + SKOS_PREFLABEL + "> \"original version\" . }";
+
+        create(res1);
+        final FcrepoResponse resp = createBody(file1, "this is some content", "text/plain");
+        final URI file1desc = resp.getLinkHeaders("describedby").get(0);
+        patch(file1desc, file1patch);
+
+        final Config config = roundtrip(URI.create(baseURI));
+
+        // verify that files exist and contain expected content
+        final File exportDir = config.getBaseDirectory();
+        final File containerFile = new File(exportDir, "fcrepo/rest/" + uuid + config.getRdfExtension());
+        final File binaryFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1.binary");
+        final File descFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1/fcr%3Ametadata"
+                + config.getRdfExtension());
+
+        assertTrue(containerFile.exists() && containerFile.isFile());
+        final Model contModel = loadModel(containerFile.getAbsolutePath());
+        assertTrue(contModel.contains(container, RDF_TYPE, CONTAINER));
+
+        assertTrue(binaryFile.exists() && binaryFile.isFile());
+        assertEquals("this is some content", IOUtils.toString(new FileInputStream(binaryFile)));
+        assertEquals(20L, binaryFile.length());
+
+        assertTrue(descFile.exists() && descFile.isFile());
+        final Model descModel = loadModel(descFile.getAbsolutePath());
+        assertTrue(descModel.contains(binary, RDF_TYPE, NON_RDF_SOURCE));
+        assertTrue(descModel.contains(binary, createProperty(PREMIS_SIZE), longLiteral("20")));
+
+        // verify that the resources exist in the repository
+        assertTrue(exists(res1));
+        assertTrue(exists(file1));
+
+        final Model model = getAsModel(file1desc);
+        assertTrue(model.contains(binary, RDF_TYPE, createResource(LDP_NON_RDF_SOURCE)));
+        assertTrue(model.contains(binary, createProperty(SKOS_PREFLABEL), "original version"));
+        assertTrue(model.contains(binary, createProperty(PREMIS_SIZE), longLiteral("20")));
+        assertTrue(model.contains(binary, createProperty(PREMIS_DIGEST),
+                createResource("urn:sha1:5ec1a3cb71c75c52cf23934b137985bd2499bd85")));
+    }
+
+    @Test
+    public void testRoundtripExternal() throws Exception {
+        final UUID uuid = UUID.randomUUID();
+        final String baseURI = serverAddress + uuid;
+        final URI res1 = URI.create(baseURI);
+        final URI file1 = URI.create(baseURI + "/file1");
+
+        final Resource container = createResource(res1.toString());
+        final Resource binary = createResource(file1.toString());
+
+        final String file1patch = "insert data { "
+            + "<" + file1.toString() + "> <" + SKOS_PREFLABEL + "> \"original version\" . }";
+
+        create(res1);
+        final URI externalURI = URI.create("http://www.example.com/file1");
+        final String externalContent = "message/external-body;access-type=URL;url=\"" + externalURI + "\"";
+        final FcrepoResponse resp = createBody(file1, "", externalContent);
+        final URI file1desc = resp.getLinkHeaders("describedby").get(0);
+        patch(file1desc, file1patch);
+
+        final Config config = roundtrip(URI.create(baseURI));
+
+        // verify that files exist and contain expected content
+        final File exportDir = config.getBaseDirectory();
+        final File containerFile = new File(exportDir, "fcrepo/rest/" + uuid + config.getRdfExtension());
+        final File binaryFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1.binary");
+        final File descFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1/fcr%3Ametadata"
+                + config.getRdfExtension());
+
+        assertTrue(containerFile.exists() && containerFile.isFile());
+        final Model contModel = loadModel(containerFile.getAbsolutePath());
+        assertTrue(contModel.contains(container, RDF_TYPE, CONTAINER));
+
+        assertTrue(binaryFile.exists() && binaryFile.isFile());
+        assertEquals("", IOUtils.toString(new FileInputStream(binaryFile)));
+        assertEquals(0L, binaryFile.length());
+
+        assertTrue(descFile.exists() && descFile.isFile());
+        final Model descModel = loadModel(descFile.getAbsolutePath());
+        assertTrue(descModel.contains(binary, RDF_TYPE, NON_RDF_SOURCE));
+        assertTrue(descModel.contains(binary, createProperty(PREMIS_SIZE), longLiteral("0")));
+        assertTrue(descModel.contains(binary, createProperty(EBU_HAS_MIME_TYPE), externalContent));
+
+        // verify that the resources exist in the repository
+        assertTrue(exists(res1));
+        assertTrue(exists(file1));
+        final FcrepoResponse redirResp = client.get(file1).disableRedirects().perform();
+        assertEquals(307, redirResp.getStatusCode());
+        assertEquals(externalURI, redirResp.getLocation());
+
+        final Model model = getAsModel(file1desc);
+        assertTrue(model.contains(binary, RDF_TYPE, createResource(LDP_NON_RDF_SOURCE)));
+        assertTrue(model.contains(binary, createProperty(SKOS_PREFLABEL), "original version"));
+        assertTrue(model.contains(binary, createProperty(PREMIS_SIZE), longLiteral("0")));
+        assertTrue(model.contains(binary, createProperty(PREMIS_DIGEST),
+                createResource("urn:sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709")));
+    }
+
+    private Literal dateLiteral(final String dateString) {
+        return createTypedLiteral(dateString, XSDdateTime);
+    }
+
+    private Literal longLiteral(final String longString) {
+        return createTypedLiteral(longString, XSDlong);
+    }
+
+    private Config roundtrip(final URI uri) throws FcrepoOperationFailedException {
+        // export resources
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(TARGET_DIR + File.separator + UUID.randomUUID());
+        config.setIncludeBinaries(true);
+        config.setResource(uri);
+        config.setRdfExtension(DEFAULT_RDF_EXT);
+        config.setRdfLanguage(DEFAULT_RDF_LANG);
+        config.setUsername(USERNAME);
+        config.setPassword(PASSWORD);
+        new Exporter(config, clientBuilder).run();
+
+        // delete container and remove tombstone
+        removeAndReset(uri);
+
+        // setup config for import to a new base URL, then perform import
+        config.setMode("import");
+        new Importer(config, clientBuilder).run();
+
+        return config;
+    }
+
+    protected Logger logger() {
+        return getLogger(RoundtripIT.class);
+    }
+}


### PR DESCRIPTION
Adding tests demonstrating import/export of:

* Metadata (including typed literals, references to other repository resources, hash URI resources)
* LDP Containers including Direct and Indirect
* Binaries (including external content redirects)

Fixes https://jira.duraspace.org/browse/FCREPO-2192