### PR TITLE
Supporting custom predicates for defining resource containment

### DIFF
--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -42,6 +42,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -58,6 +59,7 @@ public class ArgParser {
     public static final String DEFAULT_RDF_LANG = "text/turtle";
     public static final String DEFAULT_RDF_EXT = getRDFExtension(DEFAULT_RDF_LANG);
     public static final String CONFIG_FILE_NAME = "importexport.config";
+    public static final String[] DEFAULT_PREDICATES = new String[]{ CONTAINS.toString() };
 
     private final Options configOptions;
     private final Options configFileOptions;
@@ -121,6 +123,15 @@ public class ArgParser {
                 .hasArg(true).numberOfArgs(1).argName("rdfLang")
                 .desc("RDF language (default: " + DEFAULT_RDF_LANG + ")")
                 .required(false).build());
+
+        // containment predicates
+        configOptions.addOption(Option.builder("p")
+                .longOpt("predicates").argName("predicates")
+                .hasArgs()
+                .valueSeparator(',')
+                .required(false)
+                .desc("Comma-separated list of predicates to define resource containment")
+                .build());
 
         // username option
         final Option userOption = Option.builder("u")
@@ -263,6 +274,7 @@ public class ArgParser {
         config.setRdfLanguage(rdfLanguage);
         config.setRdfExtension(getRDFExtension(rdfLanguage));
         config.setSource(cmd.getOptionValue('s'));
+        config.setPredicates((cmd.getOptionValues('p') == null) ? DEFAULT_PREDICATES : cmd.getOptionValues('p'));
 
         return config;
     }

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -32,6 +32,7 @@ public class Config {
     private URI source;
     private File baseDirectory;
     private boolean includeBinaries;
+    private String[] predicates;
     private String rdfExtension;
     private String rdfLanguage;
     private String username;
@@ -167,6 +168,22 @@ public class Config {
         } else {
             return resource;
         }
+    }
+
+    /**
+     * Get the predicates that define resource containment
+     * @return An array of predicates
+     */
+    public String[] getPredicates() {
+        return predicates;
+    }
+
+    /**
+     * Set the predicates that define resource containment
+     * @param predicates An array of predicates
+     */
+    public void setPredicates(final String[] predicates) {
+        this.predicates = predicates;
     }
 
     /**

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -19,8 +19,8 @@ package org.fcrepo.importexport.exporter;
 
 import static org.apache.commons.io.IOUtils.copy;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
-import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -145,8 +145,10 @@ public class Exporter implements TransferProcess {
     private void exportMembers(final File file) {
         try {
             final Model model = createDefaultModel().read(new FileInputStream(file), null, config.getRdfLanguage());
-            for (final NodeIterator it = model.listObjectsOfProperty(CONTAINS); it.hasNext();) {
-                export(URI.create(it.nextNode().toString()));
+            for (final String p : config.getPredicates()) {
+                for (final NodeIterator it = model.listObjectsOfProperty(createProperty(p)); it.hasNext();) {
+                    export(URI.create(it.nextNode().toString()));
+                }
             }
         } catch (FileNotFoundException ex) {
             logger.warn("Unable to parse file: {}", ex.toString());

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import static java.lang.System.getProperty;
 import static org.fcrepo.importexport.ArgParser.CONFIG_FILE_NAME;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 
 /**
  * @author awoods
@@ -58,6 +59,7 @@ public class ArgParserTest {
         Assert.assertTrue(config.isExport());
         Assert.assertEquals(new File("/tmp/rdf"), config.getBaseDirectory());
         Assert.assertEquals(false, config.isIncludeBinaries());
+        Assert.assertEquals(new String[]{ CONTAINS.toString() }, config.getPredicates());
         Assert.assertEquals(".jsonld", config.getRdfExtension());
         Assert.assertEquals("application/ld+json", config.getRdfLanguage());
         Assert.assertEquals(new URI("http://localhost:8080/rest/1"), config.getResource());
@@ -69,6 +71,7 @@ public class ArgParserTest {
         Assert.assertTrue(config.isExport());
         Assert.assertEquals(new File("/tmp/rdf"), config.getBaseDirectory());
         Assert.assertEquals(false, config.isIncludeBinaries());
+        Assert.assertEquals(new String[]{ CONTAINS.toString() }, config.getPredicates());
         Assert.assertEquals(".ttl", config.getRdfExtension());
         Assert.assertEquals("text/turtle", config.getRdfLanguage());
         Assert.assertEquals(new URI("http://localhost:8080/rest/1"), config.getResource());
@@ -92,6 +95,8 @@ public class ArgParserTest {
         writer.append("http://localhost:8080/rest/test\n");
         writer.append("-d\n");
         writer.append("/tmp/import-export-dir\n");
+        writer.append("-p\n");
+        writer.append("http://www.w3.org/ns/ldp#contains,http://example.org/custom\n");
         writer.flush();
 
         final String[] args = new String[]{"-c", configFile.getAbsolutePath()};
@@ -99,6 +104,8 @@ public class ArgParserTest {
         Assert.assertTrue(config.isExport());
         Assert.assertEquals(new File("/tmp/import-export-dir"), config.getBaseDirectory());
         Assert.assertEquals(true, config.isIncludeBinaries());
+        Assert.assertEquals(new String[]{"http://www.w3.org/ns/ldp#contains", "http://example.org/custom"},
+                config.getPredicates());
         Assert.assertEquals(".ttl", config.getRdfExtension());
         Assert.assertEquals("text/turtle", config.getRdfLanguage());
         Assert.assertEquals(URI.create("http://localhost:8080/rest/test"), config.getResource());

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -67,6 +67,7 @@ public class ExporterTest {
     private Config noBinaryArgs;
     private Config metadataArgs;
     private String exportDirectory = "target/export";
+    private String[] predicates = new String[]{ CONTAINS.toString() };
 
     @Before
     public void setUp() throws Exception {
@@ -85,6 +86,7 @@ public class ExporterTest {
         args.setMode("export");
         args.setBaseDirectory(exportDirectory);
         args.setIncludeBinaries(true);
+        args.setPredicates(predicates);
         args.setRdfExtension(".jsonld");
         args.setRdfLanguage("application/ld+json");
         args.setResource(resource);
@@ -93,6 +95,7 @@ public class ExporterTest {
         binaryArgs.setMode("export");
         binaryArgs.setBaseDirectory(exportDirectory);
         binaryArgs.setIncludeBinaries(true);
+        binaryArgs.setPredicates(predicates);
         binaryArgs.setRdfExtension(".jsonld");
         binaryArgs.setRdfLanguage("application/ld+json");
         binaryArgs.setResource(resource3);
@@ -101,6 +104,7 @@ public class ExporterTest {
         noBinaryArgs.setMode("export");
         noBinaryArgs.setBaseDirectory(exportDirectory);
         noBinaryArgs.setIncludeBinaries(false);
+        noBinaryArgs.setPredicates(predicates);
         noBinaryArgs.setRdfExtension(".jsonld");
         noBinaryArgs.setRdfLanguage("application/ld+json");
         noBinaryArgs.setResource(resource3);
@@ -108,6 +112,7 @@ public class ExporterTest {
         metadataArgs = new Config();
         metadataArgs.setMode("export");
         metadataArgs.setBaseDirectory(exportDirectory);
+        metadataArgs.setPredicates(predicates);
         metadataArgs.setRdfExtension(".jsonld");
         metadataArgs.setRdfLanguage("application/ld+json");
         metadataArgs.setResource(resource);

--- a/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
@@ -40,6 +40,7 @@ import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_EXT;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_LANG;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -51,6 +52,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class ImporterIT extends AbstractResourceIT {
 
     private FcrepoClient client;
+    private String[] predicates = new String[]{ CONTAINS.toString() };
 
     public ImporterIT() {
         super();
@@ -79,6 +81,7 @@ public class ImporterIT extends AbstractResourceIT {
         config.setMode("export");
         config.setBaseDirectory(exportPath);
         config.setIncludeBinaries(true);
+        config.setPredicates(predicates);
         config.setRdfExtension(DEFAULT_RDF_EXT);
         config.setRdfLanguage(DEFAULT_RDF_LANG);
         config.setResource(parent.toString());
@@ -119,6 +122,7 @@ public class ImporterIT extends AbstractResourceIT {
         config.setMode("import");
         config.setIncludeBinaries(true);
         config.setBaseDirectory(referencePath);
+        config.setPredicates(predicates);
         config.setRdfExtension(DEFAULT_RDF_EXT);
         config.setRdfLanguage(DEFAULT_RDF_LANG);
         config.setResource(serverAddress);
@@ -149,6 +153,7 @@ public class ImporterIT extends AbstractResourceIT {
         final Config config = new Config();
         config.setMode("import");
         config.setBaseDirectory(indirectPath);
+        config.setPredicates(predicates);
         config.setRdfExtension(DEFAULT_RDF_EXT);
         config.setRdfLanguage(DEFAULT_RDF_LANG);
         config.setResource(serverAddress);

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -46,6 +46,7 @@ import static org.apache.jena.riot.RDFDataMgr.loadModel;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_EXT;
 import static org.fcrepo.importexport.ArgParser.DEFAULT_RDF_LANG;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
 import static org.junit.Assert.assertEquals;
@@ -341,6 +342,7 @@ public class RoundtripIT extends AbstractResourceIT {
         config.setBaseDirectory(TARGET_DIR + File.separator + UUID.randomUUID());
         config.setIncludeBinaries(true);
         config.setResource(uri);
+        config.setPredicates(new String[]{ CONTAINS.toString() });
         config.setRdfExtension(DEFAULT_RDF_EXT);
         config.setRdfLanguage(DEFAULT_RDF_LANG);
         config.setUsername(USERNAME);


### PR DESCRIPTION
* Allows specifying one or more predicates to define resource containment.
* By default ldp:contains is used

Fixes https://jira.duraspace.org/browse/FCREPO-2225