### PR TITLE
update version to 0.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.fcrepo.importexport</groupId>
   <artifactId>fcrepo-import-export</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 


### PR DESCRIPTION
Typically, the first released version of an artifact would be 0.1.0 (as opposed to 0.0.1). This updates the current snapshot value to reflect that.