### PR TITLE
Write unmodified data directory to config file even when exporting Bags

### DIFF
--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -24,10 +24,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.fcrepo.client.FcrepoClient;
@@ -387,8 +385,8 @@ public class ArgParser {
         // Write config to file
         try {
             final YamlWriter writer = new YamlWriter(new FileWriter(configFile));
-            logger.debug("YAML output is ({})", getMap(config).toString());
-            writer.write(getMap(config));
+            logger.debug("YAML output is ({})", config.getMap().toString());
+            writer.write(config.getMap());
             writer.close();
             logger.info("Saved configuration to: {}", configFile.getPath());
 
@@ -513,36 +511,4 @@ public class ArgParser {
                 key, value), lineNumber);
         }
     }
-
-    /**
-     * Generate a HashMap suitable for serializing to Yaml from a Config
-     *
-     * @param config the config to turn into a Hashmap
-     * @return Map key value pairs of configuration
-     */
-    public static Map<String, String> getMap(final Config config) {
-        final Map<String, String> map = new HashMap<String, String>();
-        map.put("mode", (config.isImport() ? "import" : "export"));
-        map.put("resource", config.getResource().toString());
-        if (!config.getMap().toString().isEmpty()) {
-            map.put("map", config.getMap().toString());
-        }
-        map.put("dir", config.getBaseDirectory().getAbsolutePath());
-        if (!config.getRdfLanguage().isEmpty()) {
-            map.put("rdfLang", config.getRdfLanguage());
-        }
-        map.put("binaries", Boolean.toString(config.isIncludeBinaries()));
-        map.put("external", Boolean.toString(config.retrieveExternal()));
-        map.put("overwriteTombstones", Boolean.toString(config.overwriteTombstones()));
-        if (config.getBagProfile() != null) {
-            map.put(BAG_PROFILE_OPTION_KEY, config.getBagProfile());
-        }
-        if (config.getBagConfigPath() != null) {
-            map.put(BAG_CONFIG_OPTION_KEY, config.getBagConfigPath());
-        }
-        final String predicates = Arrays.stream(config.getPredicates()).collect(Collectors.joining(","));
-        map.put("predicates", predicates);
-        return map;
-    }
-
 }

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -25,8 +25,10 @@ import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;
@@ -72,7 +74,7 @@ public class Config {
      * @return true if import config
      */
     public boolean isImport() {
-        return mode.equalsIgnoreCase("import");
+        return mode != null && mode.equalsIgnoreCase("import");
     }
 
     /**
@@ -401,12 +403,22 @@ public class Config {
         if (this.getSource() != null && this.getDestination() != null) {
             map.put("map", this.getSource() + "," + this.getDestination());
         }
-        map.put("dir", this.getBaseDirectory().getAbsolutePath());
+        map.put("dir", this.baseDirectory.getAbsolutePath());
         if (!this.getRdfLanguage().isEmpty()) {
             map.put("rdfLang", this.getRdfLanguage());
         }
         map.put("binaries", Boolean.toString(this.includeBinaries));
         map.put("external", Boolean.toString(this.retrieveExternal));
+        map.put("overwriteTombstones", Boolean.toString(this.overwriteTombstones()));
+        if (this.getBagProfile() != null) {
+            map.put("bag-profile", this.getBagProfile());
+        }
+        if (this.getBagConfigPath() != null) {
+            map.put("bag-config", this.getBagConfigPath());
+        }
+        final String predicates = Arrays.stream(this.getPredicates()).collect(Collectors.joining(","));
+        map.put("predicates", predicates);
+
         return map;
     }
 

--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -157,7 +157,7 @@ public interface TransferProcess {
                 sha1FileMap.put(file, checksum);
             });
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Error reading manifest: {}", manifestFile.toString()), e);
+            throw new RuntimeException("Error reading manifest: " + manifestFile.toString(), e);
         }
         return sha1FileMap;
     }

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -275,6 +275,7 @@ public class ArgParserTest {
         Assert.assertEquals("default", config.getBagProfile());
         Assert.assertEquals("path/config.yaml", config.getBagConfigPath());
         Assert.assertEquals(new File("/tmp/rdf/data"), config.getBaseDirectory());
+        Assert.assertEquals("/tmp/rdf", config.getMap().get("dir"));
         Assert.assertEquals("text/turtle", config.getRdfLanguage());
         Assert.assertEquals(".ttl", config.getRdfExtension());
 


### PR DESCRIPTION
* Use unmodified path when saving base directory to config file (to prevent "/data" being added twice)
* Remove redundant config-file-generation code

Fixes https://jira.duraspace.org/browse/FCREPO-2462