### PR TITLE
Improve mapping when source and/or destination URIs end with slashes

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -226,8 +226,17 @@ public class Config {
         if (map.length == 2 && map[0] != null && map[1] != null) {
             this.source = URI.create(map[0]);
             this.destination = URI.create(map[1]);
+            checkTrailingSlashes(this.source.toString(), this.destination.toString());
         } else {
             throw new IllegalArgumentException("The map should contain the export and import baseURLs");
+        }
+    }
+
+    private static void checkTrailingSlashes(final String source, final String destination) {
+        if ((source.endsWith("/") && !destination.endsWith("/")) ||
+            (!source.endsWith("/") && destination.endsWith("/"))) {
+            logger.warn("Possible mismatch between the source and destination URIs: one ends with a trailing "
+                + "slash but the other does not: \"{}\" -> \"{}\"", source, destination);
         }
     }
 

--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -134,6 +134,9 @@ public interface TransferProcess {
         if (sourcePath != null && destinationPath != null) {
             path = path.replaceFirst(destinationPath, sourcePath);
         }
+        if (extension != null && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
         return new File(baseDir, encodePath(path) + extension);
     }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -22,7 +22,6 @@ import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.INBOUND_REFERENCES;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
@@ -78,7 +77,6 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.rdf.model.ResIterator;
-import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 
 /**
@@ -337,16 +335,15 @@ public class Exporter implements TransferProcess {
 
     private void exportMembers(final File file, final URI parentURI) {
         try {
-            final Resource parent = createResource(parentURI.toString());
             final Model model = createDefaultModel().read(new FileInputStream(file), null, config.getRdfLanguage());
             for (final String p : config.getPredicates()) {
-                final NodeIterator members = model.listObjectsOfProperty(parent, createProperty(p));
+                final NodeIterator members = model.listObjectsOfProperty(createProperty(p));
                 while (members.hasNext()) {
                     export(URI.create(members.nextNode().toString()));
                 }
 
                 if (config.retrieveInbound()) {
-                    final ResIterator inbound = model.listSubjectsWithProperty(createProperty(p), parent);
+                    final ResIterator inbound = model.listSubjectsWithProperty(createProperty(p));
                     while (inbound.hasNext()) {
                         export(URI.create(inbound.next().toString()));
                     }

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -616,13 +616,17 @@ public class Importer implements TransferProcess {
     }
 
     private File fileForContainerURI(final URI uri) {
-        return fileForURI(uri, config.getSourcePath(), config.getDestinationPath(), config.getBaseDirectory(),
-                config.getRdfExtension());
+        return fileForURI(withSlash(uri), config.getSourcePath(), config.getDestinationPath(),
+                config.getBaseDirectory(), config.getRdfExtension());
     }
 
     private File directoryForContainer(final URI uri) {
-        return TransferProcess.directoryForContainer(uri, config.getSourcePath(), config.getDestinationPath(),
-                config.getBaseDirectory());
+        return TransferProcess.directoryForContainer(withSlash(uri), config.getSourcePath(),
+                config.getDestinationPath(), config.getBaseDirectory());
+    }
+
+    private static URI withSlash(final URI uri) {
+        return uri.toString().endsWith("/") ? uri : URI.create(uri.toString() + "/");
     }
 
     /**

--- a/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
@@ -257,6 +257,28 @@ public class ImporterIT extends AbstractResourceIT {
         assertTrue(resourceExists(resourceURI));
     }
 
+    @Test
+    public void testImportMappedTrailingSlash() throws Exception {
+        final URI sourceURI = URI.create("http://localhost:8080/rest/dev/");
+        final URI resourceURI = URI.create(serverAddress + "prod2/");
+        final URI childURI = URI.create(serverAddress + "prod2/asdf/");
+
+        final Config config = new Config();
+        config.setMode("import");
+        config.setBaseDirectory(TARGET_DIR + "/test-classes/sample/mapped");
+        config.setResource(childURI.toString());
+        config.setMap(new String[]{sourceURI.toString(), resourceURI.toString()});
+        config.setUsername(USERNAME);
+        config.setPassword(PASSWORD);
+
+        // run import
+        final Importer importer = new Importer(config, clientBuilder);
+        importer.run();
+
+        // verify one title and one hasMember
+        assertTrue(resourceExists(childURI));
+    }
+
     private int count(final String triples, final String triple) {
         int count = 0;
         final String[] arr = triples.split("\\n");


### PR DESCRIPTION
* Log when there is a mismatch (one ends with slash but the other doesn't)
* Make source/destination substitution work when they end with slashes

Fixes https://jira.duraspace.org/browse/FCREPO-2467