### PR TITLE
Compatibility with Windows

### DIFF
--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -623,7 +623,7 @@ public class Importer implements TransferProcess {
 
     private URI uriForFile(final File f) {
         // get path of file relative to the data directory
-        String relative = config.getBaseDirectory().toPath().relativize(f.toPath()).toString();
+        String relative = config.getBaseDirectory().toURI().relativize(f.toURI()).toString();
         relative = TransferProcess.decodePath(relative);
 
         // rebase the path on the destination uri (translating source/destination if needed)

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -308,6 +308,8 @@ public class ArgParserTest {
     @Test
     public void retrieveConfig() {
         final File configFile = new File("src/test/resources/configs/importexport.yml");
+        final File dir = new File("/tmp/rdf");
+        final File baseDir = new File(dir, "data");
         final Config config = parser.retrieveConfig(configFile);
 
         Assert.assertEquals("http://www.w3.org/ns/ldp#contains", config.getPredicates()[0]);
@@ -315,8 +317,8 @@ public class ArgParserTest {
         Assert.assertEquals(URI.create("http://localhost:8080/rest/2"), config.getSource());
         Assert.assertEquals("default", config.getBagProfile());
         Assert.assertEquals("path/config.yaml", config.getBagConfigPath());
-        Assert.assertEquals(new File("/tmp/rdf/data"), config.getBaseDirectory());
-        Assert.assertEquals("/tmp/rdf", config.getMap().get("dir"));
+        Assert.assertEquals(baseDir, config.getBaseDirectory());
+        Assert.assertEquals(dir.getAbsolutePath(), config.getMap().get("dir"));
         Assert.assertEquals("text/turtle", config.getRdfLanguage());
         Assert.assertEquals(".ttl", config.getRdfExtension());
 
@@ -327,10 +329,11 @@ public class ArgParserTest {
 
     @Test
     public void testSerializedConfigCustom() {
+        final File baseDir = new File("/path/to/export");
         final String[] args = new String[] {"-m", "import",
                                             "-r", "http://localhost:8686/rest",
                                             "-M", "http://localhost:8686/rest,http://localhost:8080/f4/rest",
-                                            "-d", "/path/to/export",
+                                            "-d", baseDir.getAbsolutePath(),
                                             "-l", "application/ld+json",
                                             "-g", "custom-profile.yml",
                                             "-G", "custom-metadata.yml",
@@ -340,7 +343,7 @@ public class ArgParserTest {
         Assert.assertEquals("import", config.get("mode"));
         Assert.assertEquals("http://localhost:8686/rest", config.get("resource"));
         Assert.assertEquals("http://localhost:8686/rest,http://localhost:8080/f4/rest", config.get("map"));
-        Assert.assertEquals("/path/to/export", config.get("dir"));
+        Assert.assertEquals(baseDir.getAbsolutePath(), config.get("dir"));
         Assert.assertEquals("application/ld+json", config.get("rdfLang"));
         Assert.assertEquals("custom-profile.yml", config.get("bag-profile"));
         Assert.assertEquals("custom-metadata.yml", config.get("bag-config"));
@@ -355,14 +358,15 @@ public class ArgParserTest {
 
     @Test
     public void testSerializedConfigDefault() {
+        final File baseDir = new File("/tmp/rdf");
         final String[] args = new String[] {"-m", "import",
                                             "-r", "http://localhost:8080/rest",
-                                            "-d", "/tmp/rdf"};
+                                            "-d", baseDir.getAbsolutePath()};
         final Map<String, String> config = parser.parseConfiguration(args).getMap();
         Assert.assertEquals("import", config.get("mode"));
         Assert.assertEquals("http://localhost:8080/rest", config.get("resource"));
         Assert.assertEquals(null, config.get("map"));
-        Assert.assertEquals("/tmp/rdf", config.get("dir"));
+        Assert.assertEquals(baseDir.getAbsolutePath(), config.get("dir"));
         Assert.assertEquals("text/turtle", config.get("rdfLang"));
         Assert.assertEquals(null, config.get("bag-profile"));
         Assert.assertEquals(null, config.get("bag-config"));

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -386,14 +386,15 @@ public class RoundtripIT extends AbstractResourceIT {
         final URI parentURI = URI.create(uri.toString() + "/res1");
         final URI childURI = URI.create(parentURI.toString() + "/child1");
         final URI fileURI = URI.create(parentURI.toString() + "/file1");
-        final File fileContent = new File("src/test/resources/binary.txt");
+        final File binaryFile = new File("src/test/resources/binary.txt");
+        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile));
 
         final FcrepoResponse response = createBody(uri, stream, "text/turtle");
         assertEquals(SC_CREATED, response.getStatusCode());
         assertEquals(uri, response.getLocation());
         create(parentURI);
         create(childURI);
-        createBody(fileURI, new FileInputStream(fileContent), "text/plain");
+        createBody(fileURI, new FileInputStream(binaryFile), "text/plain");
 
         roundtrip(uri, false);
 
@@ -403,15 +404,16 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(exists(parentURI));
         assertTrue(exists(childURI));
         assertTrue(exists(fileURI));
-        assertEquals("this is some content\n", getAsString(fileURI));
+        assertEquals(binaryContent, getAsString(fileURI));
     }
 
     @Test
     public void testRoundtripOverwriteBinary() throws Exception {
         final URI fileURI = URI.create(serverAddress + UUID.randomUUID());
-        final File fileContent = new File("src/test/resources/binary.txt");
+        final File binaryFile = new File("src/test/resources/binary.txt");
+        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile));
 
-        final FcrepoResponse response = createBody(fileURI, new FileInputStream(fileContent), "text/plain");
+        final FcrepoResponse response = createBody(fileURI, new FileInputStream(binaryFile), "text/plain");
         assertEquals(SC_CREATED, response.getStatusCode());
         assertEquals(fileURI, response.getLocation());
 
@@ -419,7 +421,7 @@ public class RoundtripIT extends AbstractResourceIT {
 
         // verify that the resources have been created
         assertTrue(exists(fileURI));
-        assertEquals("this is some content\n", getAsString(fileURI));
+        assertEquals(binaryContent, getAsString(fileURI));
     }
 
     private Literal dateLiteral(final String dateString) {


### PR DESCRIPTION
Fixed various path-related issues tests, path-generation algorithm so that import/export tool can run and build on Windows.  Also updated an IT so that test results are not affected by platform-specific line ending differences in round-tripped test data.

Resolves FCREPO-2495