### PR TITLE
Implements export of WebACs from Fedora 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- We do NOT want to rely on a snapshot dependency, but changes were 
       necessary in the fcrepo-java-client that haven't made it into a stable release. -->
-    <fcrepo.version>5.0.2</fcrepo.version>
+    <fcrepo.version>5.1.0-RC-2</fcrepo.version>
     <fcrepo-java-client.version>0.4.0</fcrepo-java-client.version>
     <bagit.version>5.0.0-BETA</bagit.version>
     <commons-cli.version>1.3.1</commons-cli.version>

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
@@ -144,9 +144,9 @@ public class ExportVersionsTest {
 
     private void mockResponse(final URI uri, final List<URI> typeLinks, final List<URI> describedbyLinks,
             final URI timemapLink, final String body) throws FcrepoOperationFailedException {
-        ResponseMocker.mockHeadResponse(client, uri, typeLinks, describedbyLinks, timemapLink);
+        ResponseMocker.mockHeadResponse(client, uri, typeLinks, describedbyLinks, timemapLink,null);
 
-        ResponseMocker.mockGetResponse(client, uri, typeLinks, describedbyLinks, timemapLink, body);
+        ResponseMocker.mockGetResponse(client, uri, typeLinks, describedbyLinks, timemapLink, null, body);
     }
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -262,6 +262,35 @@ public class ExporterIT extends AbstractResourceIT {
         assertTrue(new File(baseDir, "/res1/file/fcr%3Aversions/" + versionLabel + ".binary").exists());
     }
 
+
+    @Test
+    public void testExportAcl() throws Exception {
+        final UUID uuid = UUID.randomUUID();
+        final String baseURI = serverAddress + uuid;
+        final URI res1 = URI.create(baseURI + "/res1");
+        final URI res1Acl = URI.create(baseURI + "/res1/fcr:acl");
+
+        create(res1);
+        create(res1Acl);
+
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(TARGET_DIR + "/" + uuid);
+        config.setResource(res1);
+        config.setRdfExtension(DEFAULT_RDF_EXT);
+        config.setRdfLanguage(DEFAULT_RDF_LANG);
+        config.setUsername(USERNAME);
+        config.setPassword(PASSWORD);
+        config.setIncludeVersions(false);
+        config.setIncludeBinaries(false);
+
+        final Exporter exporter = new Exporter(config, clientBuilder);
+        exporter.run();
+
+        final File baseDir = new File(config.getBaseDirectory(), "/fcrepo/rest/" + uuid);
+        assertTrue(new File(baseDir, "/res1" + DEFAULT_RDF_EXT).exists());
+        assertTrue(new File(baseDir, "/res1/fcr%3Aacl" + DEFAULT_RDF_EXT).exists());
+    }
     private void createMemento(final URI uri, final String rfc1123Date) throws FcrepoOperationFailedException {
         final InputStream body = clientBuilder.build().get(uri).accept(DEFAULT_RDF_LANG).perform().getBody();
         final String timeMap = uri.toString() + "/fcr:versions";

--- a/src/test/java/org/fcrepo/importexport/test/util/ResponseMocker.java
+++ b/src/test/java/org/fcrepo/importexport/test/util/ResponseMocker.java
@@ -55,7 +55,8 @@ public abstract class ResponseMocker {
      * @throws FcrepoOperationFailedException client failures
      */
     public static void mockHeadResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
-            final List<URI> describedbyLinks, final URI timemapLink) throws FcrepoOperationFailedException {
+                                        final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink)
+            throws FcrepoOperationFailedException {
         final HeadBuilder headBuilder = mock(HeadBuilder.class);
         final FcrepoResponse headResponse = mock(FcrepoResponse.class);
         when(client.head(eq(uri))).thenReturn(headBuilder);
@@ -67,6 +68,10 @@ public abstract class ResponseMocker {
         when(headResponse.getLinkHeaders(eq("type"))).thenReturn(typeLinks);
         if (timemapLink != null) {
             when(headResponse.getLinkHeaders(eq("timemap"))).thenReturn(Arrays.asList(timemapLink));
+        }
+
+        if (aclLink != null) {
+            when(headResponse.getLinkHeaders(eq("acl"))).thenReturn(Arrays.asList(aclLink));
         }
     }
 
@@ -81,7 +86,8 @@ public abstract class ResponseMocker {
      * @throws FcrepoOperationFailedException client failures
      */
     public static void mockGetResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
-                                       final List<URI> describedbyLinks, final URI timemapLink, final String body)
+                                       final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink,
+                                       final String body)
         throws FcrepoOperationFailedException {
         final GetBuilder getBuilder = mock(GetBuilder.class);
         final FcrepoResponse getResponse = mock(FcrepoResponse.class);
@@ -103,6 +109,9 @@ public abstract class ResponseMocker {
             when(getResponse.getLinkHeaders(eq("timemap"))).thenReturn(Arrays.asList(timemapLink));
         }
 
+        if (aclLink != null) {
+            when(getResponse.getLinkHeaders(eq("acl"))).thenReturn(Arrays.asList(aclLink));
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves:  https://jira.duraspace.org/browse/FCREPO-2980

This feature is covered by an integration test.  

To test it manually:
1. start a 5.1.0-RC-2 instance fedora instance
2. create a resource resourceA
3. create an acl and PUT it to resourceA/fcr:acl
4. perform and export
5. verify that resourceA.ttl and resourceA/fcr%3Aacl.ttl exist.
