### PR TITLE
Ensures that objects of rdf:type predicates in the ldp: namespace are…

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -69,7 +69,8 @@ public abstract class FcrepoConstants {
     public static final Property LAST_MODIFIED_BY = createProperty(REPOSITORY_NAMESPACE + "lastModifiedBy");
 
     public static final String FCR_VERSIONS_PATH = "fcr:versions";
-    public static final Property MEMENTO = createProperty("http://mementoweb.org/ns#Memento");
-    public static final Property TIMEMAP = createProperty("http://mementoweb.org/ns#TimeMap");
+    public static final String MEMENTO_NAMESPACE = "http://mementoweb.org/ns#";
+    public static final Property MEMENTO = createProperty(MEMENTO_NAMESPACE + "Memento");
+    public static final Property TIMEMAP = createProperty(MEMENTO_NAMESPACE + "TimeMap");
     public static final Property HAS_VERSION_LABEL = createProperty(REPOSITORY_NAMESPACE + "hasVersionLabel");
 }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -259,7 +259,7 @@ public class Exporter implements TransferProcess {
         logger.trace("HEAD " + uri);
         try (FcrepoResponse response = client().head(uri).disableRedirects().perform()) {
             if (response.getStatusCode() == 404 && uri.toString().endsWith("fcr:acl")) {
-                logger.info("ACL {} not found and thus will not be exported.", uri);
+                logger.debug("ACL {} not found and thus will not be exported.", uri);
                 return;
             }
 

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -36,6 +36,7 @@ import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.LDP_NAMESPACE;
 import static org.fcrepo.importexport.common.FcrepoConstants.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO_NAMESPACE;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.PAIRTREE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
@@ -574,6 +575,7 @@ public class Importer implements TransferProcess {
      */
     private boolean forbiddenType(final Resource resource) {
         return resource.getNameSpace().equals(REPOSITORY_NAMESPACE)
+            || resource.getNameSpace().equals(MEMENTO_NAMESPACE)
             || resource.getNameSpace().equals(LDP_NAMESPACE);
     }
 
@@ -604,10 +606,11 @@ public class Importer implements TransferProcess {
         ensureExists(parent(uri));
 
         final FcrepoResponse response;
+        final ByteArrayInputStream emptyStream = new ByteArrayInputStream(new byte[]{});
         if (fileForBinaryURI(uri, false).exists() || fileForBinaryURI(uri, true).exists()) {
-            response = client().put(uri).body(new ByteArrayInputStream(new byte[]{})).perform();
+            response = client().put(uri).body(emptyStream).perform();
         } else if (fileForContainerURI(uri).exists()) {
-            response = client().put(uri).body(new ByteArrayInputStream("".getBytes()), "text/turtle").perform();
+            response = client().put(uri).body(emptyStream, "text/turtle").perform();
         } else {
             return;
         }

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -25,7 +25,6 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.fcrepo.importexport.common.FcrepoConstants.BINARY_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
-import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.DESCRIBEDBY;
@@ -35,10 +34,10 @@ import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MIME_TYPE;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_SIZE;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_DATE;
+import static org.fcrepo.importexport.common.FcrepoConstants.LDP_NAMESPACE;
 import static org.fcrepo.importexport.common.FcrepoConstants.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.PAIRTREE;
-import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
 import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
 import static org.fcrepo.importexport.common.TransferProcess.fileForBinary;
@@ -574,10 +573,8 @@ public class Importer implements TransferProcess {
      * @return true if the resource represents a type that may not be added/removed explicitly
      */
     private boolean forbiddenType(final Resource resource) {
-         return resource.getNameSpace().equals(REPOSITORY_NAMESPACE)
-             || resource.getURI().equals(CONTAINER.getURI())
-             || resource.getURI().equals(NON_RDF_SOURCE.getURI())
-             || resource.getURI().equals(RDF_SOURCE.getURI());
+        return resource.getNameSpace().equals(REPOSITORY_NAMESPACE)
+            || resource.getNameSpace().equals(LDP_NAMESPACE);
     }
 
     /**
@@ -610,8 +607,7 @@ public class Importer implements TransferProcess {
         if (fileForBinaryURI(uri, false).exists() || fileForBinaryURI(uri, true).exists()) {
             response = client().put(uri).body(new ByteArrayInputStream(new byte[]{})).perform();
         } else if (fileForContainerURI(uri).exists()) {
-            response = client().put(uri).body(new ByteArrayInputStream(
-                    "<> a <http://www.w3.org/ns/ldp#Container> .".getBytes()), "text/turtle").perform();
+            response = client().put(uri).body(new ByteArrayInputStream("".getBytes()), "text/turtle").perform();
         } else {
             return;
         }

--- a/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
@@ -45,7 +45,6 @@ import org.fcrepo.importexport.importer.Importer;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -53,7 +52,6 @@ import org.slf4j.Logger;
  * @author awoods
  * @since 2016-09-18
  */
-@Ignore  //TODO fix these tests
 public class ImporterIT extends AbstractResourceIT {
 
     private FcrepoClient client;
@@ -114,9 +112,10 @@ public class ImporterIT extends AbstractResourceIT {
                 binaryText, IOUtils.toString(client.get(binary).perform().getBody(), "UTF-8"));
     }
 
+    @Test
     public void testCorruptedBinary() throws Exception {
-        final URI sourceURI = URI.create("http://localhost:8080/fcrepo/rest");
-        final URI binaryURI = URI.create("http://localhost:8080/fcrepo/rest/bin1");
+        final URI sourceURI = URI.create(serverAddress);
+        final URI binaryURI = URI.create(serverAddress + "/bin1");
         final String referencePath = TARGET_DIR + "/test-classes/sample/corrupted";
         System.out.println("Importing from " + referencePath);
 

--- a/src/test/resources/sample/indirect/fcrepo/rest/indirect/1.ttl
+++ b/src/test/resources/sample/indirect/fcrepo/rest/indirect/1.ttl
@@ -22,7 +22,7 @@
 @prefix pcdm: <http://pcdm.org/models#> .
 
 
-<http://localhost:8080/fcrepo/rest/indirect/1> a fedora:Container , fedora:Resource ;
+<http://localhost:8080/fcrepo/rest/indirect/1> a fedora:Container , fedora:Resource , ldp:BasicContainer ;
 	fedora:lastModifiedBy "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
 	fedora:createdBy "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
 	fedora:created "2016-09-22T17:21:33.422Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;


### PR DESCRIPTION
… removed before import.

This fix also brings the ImporterIT integration tests back into the mix (ie they
are no longer ignored).

Resolves: https://jira.duraspace.org/browse/FCREPO-3001
*********
This PR widens the ban on forbidden types on import to all types in the LDP namespace.  The functionality is covered by integration tests.  For manual test: 

1.  start a fresh repo
2. create a container resource1 and a nested binary
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container
```
3. Add a triple
```
curl -X PATCH -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container --data-binary "INSERT { <> <http://example.org/test> \"something\" } WHERE {}" 
```
4. Create a binary
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary --data-binary "hello world" -H "Content-Type: text/plain"
```
5.  Run the import export tool: 
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode export --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir
```
6. start a fresh repo:  stop report, remove fcrepo4-data and start the repo
7.  Import the data: 
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode import --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir
```
8.  Verify the resources have been successfully imported.

