### PR TITLE
Prevents versions from being imported when the include versions flag …

### DIFF
--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -337,6 +337,7 @@ public class Importer implements TransferProcess {
         final String sourceRelativePath =
                 config.getBaseDirectory().toPath().relativize(f.toPath()).toString();
         final String filePath = f.getPath();
+
         if (filePath.endsWith(BINARY_EXTENSION) || filePath.endsWith(EXTERNAL_RESOURCE_EXTENSION)) {
             // ... this is only expected to happen when binaries and metadata are written to the same directory...
             if (config.isIncludeBinaries()) {
@@ -351,6 +352,18 @@ public class Importer implements TransferProcess {
             logger.info("Skipping file with unexpected extension ({}).", sourceRelativePath);
             return;
         } else {
+
+            //always skip timemaps since they are derived from the mementos they contain.
+            if (sourceRelativePath.endsWith("fcr%3Aversions" + config.getRdfExtension())) {
+                logger.debug("Skipping {} :  Time maps are never imported.", sourceRelativePath);
+                return;
+            }
+
+            //skip versions when include versions flag is false.
+            if (!config.includeVersions() && filePath.contains("fcr%3Aversions")) {
+                logger.debug("Skipping {}: Versions import disabled.", sourceRelativePath);
+                return;
+            }
 
             FcrepoResponse response = null;
             URI destinationUri = null;


### PR DESCRIPTION
…is false.

Resolves: https://jira.duraspace.org/browse/FCREPO-3002

************

1. Start a fresh repo
create a container resource1 and a nested binary
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container
```
2. Create a version
```
curl -X POST -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/fcr:versions
```
3. Run the import export tool:
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode export --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions  --rdfLang "text/turtle" --dir export-dir
```
4. Start a fresh repo: stop report, remove fcrepo4-data and start the repo
5. Import the data with versions disabled.
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode import --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions false --rdfLang "text/turtle" --dir export-dir
```
6. Verify the resources have been successfully imported and that there are no fcr:versions related warnings or error messages.

7.  Repeat 4. 
8.  Import data with versions enabled
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode import --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions  --rdfLang "text/turtle" --dir export-dir
```
9. Verify the resources have been successfully imported and that there are fcr:versions related warnings or error messages.

NOTE:  Version import is coming in a subsequent PR.  Thus you should not expect versions to successfully import when the versions flag is set to true.

