### PR TITLE
Adds support for importing 5.x versions (mementos).  Included in this…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
     <shade.plugin.version>2.4.3</shade.plugin.version>
     <slf4j.version>1.7.10</slf4j.version>
     <cargo.version>1.4.12</cargo.version>
+    <javax.ws.rs.version>2.0</javax.ws.rs.version>
+    <jersey.version>2.29</jersey.version>
     <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
   </properties>
 
@@ -81,6 +83,18 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${javax.ws.rs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
 
     <!-- testing -->

--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -33,6 +33,11 @@ import org.apache.jena.rdf.model.Resource;
 public abstract class FcrepoConstants {
 
     public static final String BINARY_EXTENSION = ".binary";
+    public static final String HEADERS_EXTENSION = ".headers";
+
+    public static final String MEMENTO_DATETIME_HEADER = "Memento-Datetime";
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+
     public static final String EXTERNAL_RESOURCE_EXTENSION = ".external";
 
     public static final String EBUCORE_NAMESPACE = "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#";

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -395,9 +395,8 @@ public class Importer implements TransferProcess {
                     logger.debug("Skipping binary {}", sourceRelativePath);
                 }
                 return;
-            } else {
-                //continue processing
-            }
+            } // else continue processing
+
         } else if (!filePath.endsWith(config.getRdfExtension())) {
             // this could be hidden files created by the OS
             logger.info("Skipping file with unexpected extension ({}).", sourceRelativePath);
@@ -447,9 +446,7 @@ public class Importer implements TransferProcess {
             }
 
 
-            if (response == null) {
-                logger.warn("Failed to import {}", f.getAbsolutePath());
-            } else if (response.getStatusCode() == 401) {
+            if (response.getStatusCode() == 401) {
                 importLogger.error("Error importing {} to {}, 401 Unauthorized", f.getAbsolutePath(),
                     destinationUri);
                 throw new AuthenticationRequiredRuntimeException();
@@ -581,7 +578,7 @@ public class Importer implements TransferProcess {
         } else {
             logger.error("Error while importing {} ({}): {}", binaryFile.getAbsolutePath(),
                     binaryResponse.getStatusCode(), IOUtils.toString(binaryResponse.getBody()));
-            return null;
+            return binaryResponse;
         }
     }
 

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -25,6 +25,7 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.fcrepo.importexport.common.FcrepoConstants.BINARY_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTENT_TYPE_HEADER;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.DESCRIBEDBY;
@@ -32,15 +33,19 @@ import static org.fcrepo.importexport.common.FcrepoConstants.EXTERNAL_RESOURCE_E
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MIME_TYPE;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_SIZE;
+import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.LDP_NAMESPACE;
 import static org.fcrepo.importexport.common.FcrepoConstants.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO;
+import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO_DATETIME_HEADER;
 import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO_NAMESPACE;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.PAIRTREE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
 import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
+import static org.fcrepo.importexport.common.FcrepoConstants.TIMEMAP;
 import static org.fcrepo.importexport.common.TransferProcess.fileForBinary;
 import static org.fcrepo.importexport.common.TransferProcess.fileForExternalResources;
 import static org.fcrepo.importexport.common.TransferProcess.fileForURI;
@@ -56,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -63,14 +69,18 @@ import java.security.NoSuchAlgorithmException;
 import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.jena.rdf.model.Property;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.client.PostBuilder;
 import org.fcrepo.client.PutBuilder;
 import org.fcrepo.importexport.common.AuthenticationRequiredRuntimeException;
 import org.fcrepo.importexport.common.Config;
@@ -92,6 +102,8 @@ import org.slf4j.Logger;
 import gov.loc.repository.bagit.domain.Bag;
 import gov.loc.repository.bagit.reader.BagReader;
 import gov.loc.repository.bagit.verify.BagVerifier;
+
+import javax.ws.rs.core.Link;
 
 /**
  * Fedora Import Utility
@@ -337,25 +349,71 @@ public class Importer implements TransferProcess {
         final String sourceRelativePath =
                 config.getBaseDirectory().toPath().relativize(f.toPath()).toString();
         final String filePath = f.getPath();
+
+        //ignore header files
+        if (filePath.endsWith(".headers")) {
+            // this could be hidden files created by the OS
+            logger.debug("Skipping .headers files ({}).", sourceRelativePath);
+            return;
+
+        }
+
+        //parse headers from headers file
+        final Map<String,List<String>> headers;
+
+        try {
+            headers = parseHeaders(getHeadersFile(f));
+        } catch (IOException ex) {
+            importLogger.error(String.format("Error reading/parsing headers file for %1$s - Message: %2$s",
+                f.getAbsolutePath(), ex.getMessage()), ex);
+            throw new RuntimeException(
+                "Error reading or parsing headers file for" + f.getAbsolutePath() + ": " + ex.toString(), ex);
+        }
+
+        //always skip timemaps since they are derived from the mementos they contain.
+        if (isTimeMap(headers)) {
+            logger.debug("Skipping {} :  TimeMaps are never imported.", sourceRelativePath);
+            return;
+        }
+
+        final boolean isMemento = isMemento(headers);
+
+        //skip versions when include versions flag is false.
+        if (!config.includeVersions() && isMemento) {
+            logger.debug("Skipping {}: Versions import disabled.", sourceRelativePath);
+            return;
+        }
+
         if (filePath.endsWith(BINARY_EXTENSION) || filePath.endsWith(EXTERNAL_RESOURCE_EXTENSION)) {
             // ... this is only expected to happen when binaries and metadata are written to the same directory...
-            if (config.isIncludeBinaries()) {
-                logger.debug("Skipping binary {}: it will be imported when its metadata is imported.",
+
+            if (!isMemento) {
+                if (config.isIncludeBinaries()) {
+                    logger.debug("Skipping binary {}: it will be imported when its metadata is imported.",
                         sourceRelativePath);
+                } else {
+                    logger.debug("Skipping binary {}", sourceRelativePath);
+                }
+                return;
             } else {
-                logger.debug("Skipping binary {}", sourceRelativePath);
+                //continue processing
             }
-            return;
         } else if (!filePath.endsWith(config.getRdfExtension())) {
             // this could be hidden files created by the OS
             logger.info("Skipping file with unexpected extension ({}).", sourceRelativePath);
             return;
-        } else {
+        }
 
-            FcrepoResponse response = null;
-            URI destinationUri = null;
-            try {
+        FcrepoResponse response = null;
+        URI destinationUri = null;
+        try {
+
+            if (isMemento) {
+                response = importMemento(f, headers);
+            } else {
+
                 final Model model = parseStream(new FileInputStream(f));
+
                 // remove the member resources that are being imported
                 for (final ResIterator it = model.listSubjects(); it.hasNext();) {
                     final URI uri = URI.create(it.next().toString());
@@ -386,40 +444,113 @@ public class Importer implements TransferProcess {
                     logger.info("Importing container {} to {}", f.getAbsolutePath(), destinationUri);
                     response = importContainer(destinationUri, sanitize(model));
                 }
+            }
 
-                if (response == null) {
-                    logger.warn("Failed to import {}", f.getAbsolutePath());
-                } else if (response.getStatusCode() == 401) {
-                    importLogger.error("Error importing {} to {}, 401 Unauthorized", f.getAbsolutePath(),
-                        destinationUri);
-                    throw new AuthenticationRequiredRuntimeException();
-                } else if (response.getStatusCode() > 204 || response.getStatusCode() < 200) {
-                    final String message = "Error while importing " + f.getAbsolutePath() + " ("
-                            + response.getStatusCode() + "): " + IOUtils.toString(response.getBody());
-                    logger.error(message);
-                    importLogger.error("Error importing {} to {}, received {}", f.getAbsolutePath(), destinationUri,
-                        response.getStatusCode());
-                } else {
-                    logger.info("Imported {}: {}", f.getAbsolutePath(), destinationUri);
-                    importLogger.info("import {} to {}", f.getAbsolutePath(), destinationUri);
-                    successCount.incrementAndGet();
+
+            if (response == null) {
+                logger.warn("Failed to import {}", f.getAbsolutePath());
+            } else if (response.getStatusCode() == 401) {
+                importLogger.error("Error importing {} to {}, 401 Unauthorized", f.getAbsolutePath(),
+                    destinationUri);
+                throw new AuthenticationRequiredRuntimeException();
+            } else if (response.getStatusCode() > 204 || response.getStatusCode() < 200) {
+                final String message = "Error while importing " + f.getAbsolutePath() + " ("
+                        + response.getStatusCode() + "): " + IOUtils.toString(response.getBody());
+                logger.error(message);
+                importLogger.error("Error importing {} to {}, received {}", f.getAbsolutePath(), destinationUri,
+                    response.getStatusCode());
+            } else {
+                logger.info("Imported {}: {}", f.getAbsolutePath(), destinationUri);
+                importLogger.info("import {} to {}", f.getAbsolutePath(), destinationUri);
+                successCount.incrementAndGet();
+            }
+        } catch (FcrepoOperationFailedException ex) {
+            importLogger.error(String.format("Error importing %1$s to %2$s, Message: %3$s", f.getAbsolutePath(),
+                destinationUri, ex.getMessage()), ex);
+            throw new RuntimeException("Error importing " + f.getAbsolutePath() + ": " + ex.toString(), ex);
+        } catch (IOException ex) {
+            importLogger.error(String.format("Error reading/parsing %1$s to %2$s, Message: %3$s",
+                    f.getAbsolutePath(), destinationUri, ex.getMessage()), ex);
+            throw new RuntimeException(
+                    "Error reading or parsing " + f.getAbsolutePath() + ": " + ex.toString(), ex);
+        } catch (URISyntaxException ex) {
+            importLogger.error(
+                String.format("Error building URI for %1$s, Message: %2$s",
+                        f.getAbsolutePath(), ex.getMessage()), ex);
+            throw new RuntimeException("Error building URI for " + f.getAbsolutePath() + ": " + ex.toString(), ex);
+        }
+    }
+
+    private FcrepoResponse importMemento(final File mementoFile, final Map<String, List<String>> headers)
+        throws IOException, FcrepoOperationFailedException {
+        final String mementoDatetime = getFirstByKey(headers, MEMENTO_DATETIME_HEADER);
+        final String contentType = getFirstByKey(headers, CONTENT_TYPE_HEADER);
+        final URI timeMapURI = getLinkValueByRel(headers, "timemap");
+        final PostBuilder builder = client().post(timeMapURI)
+            .body(new FileInputStream(mementoFile), contentType)
+            .addHeader(MEMENTO_DATETIME_HEADER, mementoDatetime);
+        return builder.perform();
+    }
+
+    private boolean hasType(final Map<String, List<String>> headers, final String typeUri) {
+        final List<String> values = headers.get("Link");
+        if (values != null) {
+            for (String linkstr : values) {
+                final Link link = Link.valueOf(linkstr);
+                if (link.getRel().equals("type") && link.getUri().toString().equals(typeUri)) {
+                    return true;
                 }
-            } catch (FcrepoOperationFailedException ex) {
-                importLogger.error(String.format("Error importing %1$s to %2$s, Message: %3$s", f.getAbsolutePath(),
-                    destinationUri, ex.getMessage()), ex);
-                throw new RuntimeException("Error importing " + f.getAbsolutePath() + ": " + ex.toString(), ex);
-            } catch (IOException ex) {
-                importLogger.error(String.format("Error reading/parsing %1$s to %2$s, Message: %3$s",
-                        f.getAbsolutePath(), destinationUri, ex.getMessage()), ex);
-                throw new RuntimeException(
-                        "Error reading or parsing " + f.getAbsolutePath() + ": " + ex.toString(), ex);
-            } catch (URISyntaxException ex) {
-                importLogger.error(
-                    String.format("Error building URI for %1$s, Message: %2$s",
-                            f.getAbsolutePath(), ex.getMessage()), ex);
-                throw new RuntimeException("Error building URI for " + f.getAbsolutePath() + ": " + ex.toString(), ex);
             }
         }
+        return false;
+    }
+
+    private boolean isMemento(final Map<String, List<String>> headers) {
+        return hasType(headers, MEMENTO.getURI());
+    }
+
+    private boolean isTimeMap(final Map<String, List<String>> headers) {
+        return hasType(headers, TIMEMAP.getURI());
+    }
+
+    private URI getLinkValueByRel(final Map<String, List<String>> headers, final String rel) {
+        final List<String> values = headers.get("Link");
+        for (String linkstr : values) {
+            final Link link = Link.valueOf(linkstr);
+            if (link.getRel().equals(rel)) {
+                return link.getUri();
+            }
+        }
+
+        return null;
+    }
+
+    private String getFirstByKey(final Map<String, List<String>> headers, final String key) {
+        final List<String> values = headers.get(key);
+        if (values != null && values.size() > 0) {
+            return values.get(0);
+        }
+
+        return null;
+    }
+
+    private File getHeadersFile(final File f) {
+        return new File(f.getParentFile(), f.getName() + HEADERS_EXTENSION);
+    }
+
+    private Map<String, List<String>> parseHeaders(final File headersFile) throws IOException {
+
+        if (!headersFile.exists()) {
+            return new HashMap<>();
+        }
+
+        //converting json to Map
+        final byte[] mapData = Files.readAllBytes(Paths.get(headersFile.toURI()));
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map<String, List<String>> headers =
+            objectMapper.readValue(mapData, new TypeReference<HashMap<String, List<String>>>() {
+            });
+        return headers;
     }
 
     private Model parseStream(final InputStream in) throws IOException {

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
@@ -146,7 +146,6 @@ public class ExportVersionsTest {
     private void mockResponse(final URI uri, final List<URI> typeLinks, final List<URI> describedbyLinks,
             final URI timemapLink, final String body) throws FcrepoOperationFailedException {
         ResponseMocker.mockHeadResponse(client, uri, typeLinks, describedbyLinks, timemapLink,null);
-
         ResponseMocker.mockGetResponse(client, uri, typeLinks, describedbyLinks, timemapLink, null, body);
     }
 
@@ -216,7 +215,6 @@ public class ExportVersionsTest {
                                                ".jsonld")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/container1/fcr%3Aversions/" + versionLabel +
             ".jsonld" + HEADERS_EXTENSION)));
-
     }
 
     @Test
@@ -263,7 +261,6 @@ public class ExportVersionsTest {
                                                versionLabel + ".jsonld")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata/fcr%3Aversions/" +
             versionLabel + ".jsonld.headers")));
-
     }
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
@@ -23,6 +23,7 @@ import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.FCR_VERSIONS_PATH;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_VERSION_LABEL;
+import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
@@ -213,6 +214,9 @@ public class ExportVersionsTest {
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/container1/fcr%3Aversions.jsonld")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/container1/fcr%3Aversions/" + versionLabel +
                                                ".jsonld")));
+        assertTrue(exporter.wroteFile(new File(basedir + "/rest/container1/fcr%3Aversions/" + versionLabel +
+            ".jsonld" + HEADERS_EXTENSION)));
+
     }
 
     @Test
@@ -252,9 +256,14 @@ public class ExportVersionsTest {
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Aversions.jsonld")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Aversions/" + versionLabel +
                                                ".binary")));
+        assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Aversions/" + versionLabel +
+            ".binary.headers")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata/fcr%3Aversions.jsonld")));
         assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata/fcr%3Aversions/" +
                                                versionLabel + ".jsonld")));
+        assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata/fcr%3Aversions/" +
+            versionLabel + ".jsonld.headers")));
+
     }
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -23,6 +23,7 @@ import static org.fcrepo.importexport.common.FcrepoConstants.BINARY_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
 import static org.fcrepo.importexport.common.FcrepoConstants.EXTERNAL_RESOURCE_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
 import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
@@ -152,6 +153,13 @@ public class ExporterTest {
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1" + BINARY_EXTENSION)));
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata.jsonld")));
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/alt_description.jsonld")));
+        Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1" + BINARY_EXTENSION +
+            HEADERS_EXTENSION)));
+        Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/file1/fcr%3Ametadata.jsonld" +
+            HEADERS_EXTENSION)));
+        Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/alt_description.jsonld" +
+            HEADERS_EXTENSION)));
+
     }
 
     @Test
@@ -416,6 +424,14 @@ class ExporterWrapper extends Exporter {
         super.writeResponse(uri, in, describedby, file);
         writtenFiles.add(file);
     }
+
+    @Override
+    void writeHeadersFile(final FcrepoResponse response, final File file) throws IOException {
+        super.writeHeadersFile(response, file);
+        writtenFiles.add(file);
+
+    }
+
     boolean wroteFile(final File file) {
         return writtenFiles.contains(file);
     }

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -131,7 +131,6 @@ public class ExporterTest {
                               final URI aclLink, final String body) throws FcrepoOperationFailedException {
         ResponseMocker.mockHeadResponse(client, uri, typeLinks, describedbyLinks, null, aclLink);
         ResponseMocker.mockGetResponse(client, uri, typeLinks, describedbyLinks,  null, aclLink, body);
-
     }
 
     @Test
@@ -159,7 +158,6 @@ public class ExporterTest {
             HEADERS_EXTENSION)));
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/alt_description.jsonld" +
             HEADERS_EXTENSION)));
-
     }
 
     @Test
@@ -320,7 +318,6 @@ public class ExporterTest {
         exporter.run();
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/1.jsonld")));
         Assert.assertTrue(exporter.wroteFile(new File(basedir + "/rest/1/fcr%3Aacl.jsonld")));
-
     }
 
     @Test (expected = AuthenticationRequiredRuntimeException.class)

--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -119,7 +119,6 @@ public abstract class AbstractResourceIT {
                 uri, response.getStatusCode(), response.getHeaderValue("Location"));
 
         return response;
-
     }
 
     protected FcrepoResponse post(final URI uri) throws FcrepoOperationFailedException {
@@ -130,7 +129,6 @@ public abstract class AbstractResourceIT {
             uri, response.getStatusCode(), response.getHeaderValue("Location"));
 
         return response;
-
     }
 
     protected FcrepoResponse get(final URI uri) throws FcrepoOperationFailedException {
@@ -141,7 +139,6 @@ public abstract class AbstractResourceIT {
             uri, response.getStatusCode(), response.getHeaderValue("Location"));
 
         return response;
-
     }
 
     protected FcrepoResponse createBody(final URI uri, final String body, final String contentType)

--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -122,6 +122,28 @@ public abstract class AbstractResourceIT {
 
     }
 
+    protected FcrepoResponse post(final URI uri) throws FcrepoOperationFailedException {
+        logger.debug("Create ---------: {}", uri);
+        final FcrepoResponse response =  clientBuilder.build().post(uri).perform();
+
+        logger().debug("Response for post {}:  status={}; location={}",
+            uri, response.getStatusCode(), response.getHeaderValue("Location"));
+
+        return response;
+
+    }
+
+    protected FcrepoResponse get(final URI uri) throws FcrepoOperationFailedException {
+        logger.debug("Create ---------: {}", uri);
+        final FcrepoResponse response =  clientBuilder.build().get(uri).perform();
+
+        logger().debug("Response for get {}:  status={}; location={}",
+            uri, response.getStatusCode(), response.getHeaderValue("Location"));
+
+        return response;
+
+    }
+
     protected FcrepoResponse createBody(final URI uri, final String body, final String contentType)
             throws FcrepoOperationFailedException {
         return createBody(uri, new ByteArrayInputStream(body.getBytes()), contentType, null);

--- a/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
@@ -41,7 +41,6 @@ import org.fcrepo.importexport.common.Config;
 import org.fcrepo.importexport.exporter.Exporter;
 import org.fcrepo.importexport.importer.Importer;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -49,7 +48,6 @@ import org.slf4j.Logger;
  * @author whikloj
  * @since 2016-12-12
  */
-@Ignore  //TODO fix these tests
 public class BagItIT extends AbstractResourceIT {
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/integration/ExecutableJarIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExecutableJarIT.java
@@ -47,7 +47,6 @@ import org.fcrepo.importexport.common.TransferProcess;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -55,7 +54,6 @@ import org.slf4j.Logger;
  * @author awoods
  * @since 2016-09-01
  */
-@Ignore  //TODO fix these tests
 public class ExecutableJarIT extends AbstractResourceIT {
 
     private static final Logger logger = getLogger(ExecutableJarIT.class);

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -259,7 +259,11 @@ public class ExporterIT extends AbstractResourceIT {
         assertTrue(new File(baseDir, "/res1/fcr%3Aversions" + DEFAULT_RDF_EXT).exists());
         assertTrue(new File(baseDir, "/res1/fcr%3Aversions/" + versionLabel + DEFAULT_RDF_EXT).exists());
         assertTrue(new File(baseDir, "/res1/res2/fcr%3Aversions/" + versionLabel + DEFAULT_RDF_EXT).exists());
+        assertTrue(new File(baseDir, "/res1/res2/fcr%3Aversions/" + versionLabel + DEFAULT_RDF_EXT + ".headers")
+            .exists());
         assertTrue(new File(baseDir, "/res1/file/fcr%3Aversions/" + versionLabel + ".binary").exists());
+        assertTrue(new File(baseDir, "/res1/file/fcr%3Aversions/" + versionLabel + ".binary.headers").exists());
+
     }
 
 

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -263,7 +263,6 @@ public class ExporterIT extends AbstractResourceIT {
             .exists());
         assertTrue(new File(baseDir, "/res1/file/fcr%3Aversions/" + versionLabel + ".binary").exists());
         assertTrue(new File(baseDir, "/res1/file/fcr%3Aversions/" + versionLabel + ".binary.headers").exists());
-
     }
 
 


### PR DESCRIPTION
… commit is a fix that ensures that the versions flag is respected on import.

Resolves: https://jira.duraspace.org/browse/FCREPO-2982
          https://jira.duraspace.org/browse/FCREPO-3002

There are integration tests covering this functionality.
********
To test manually:

1. start up a repository
2. create a container
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container
```
3. Snap a version
```
curl -X POST -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/fcr:versions
```
4. Change the container
```
curl -X PATCH -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container --data-binary "INSERT { <> <http://example.org/test> \"something\" } WHERE {}" -H "Content-Type: application/sparql-update"
```
5. Create a binary within the container
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary --data-binary "hello world" -H "Content-Type: text/plain"
```
6. Snap a version of the binary
```
curl -X POST -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary/fcr:versions
```
7. Snap a version of the binary metadata
```
curl -X POST -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary/fcr:metadata/fcr:versions
```
8. Change the binary
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary --data-binary "hello world 2" -H "Content-Type: text/plain"
```
9. Change the binary metadata
```
curl -X PATCH -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container/binary/fcr:metadata --data-binary "INSERT { <> <http://example.org/test> \"something\" } WHERE {}" -H "Content-Type: application/sparql-update"
```
10. Perform export
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode export --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir -u fedoraAdmin:fedoraAdmin
```
11. Wipe and restart fresh fcrepo4 - NOTE:  make sure you are using the `-Dfcrepo.properties.management=relaxed` flag when starting Fedora.
12. Perform import
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode import --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir -u fedoraAdmin:fedoraAdmin
```
13. Verify that each of the resources match what is expected.


