### PR TITLE
Fixes Direct and Indirect Container integration tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <shade.plugin.version>2.4.3</shade.plugin.version>
     <slf4j.version>1.7.10</slf4j.version>
     <cargo.version>1.4.12</cargo.version>
-    <javax.ws.rs.version>2.0</javax.ws.rs.version>
     <jersey.version>2.29</jersey.version>
     <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
   </properties>
@@ -84,19 +83,7 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-
+    
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -48,6 +48,9 @@ public abstract class FcrepoConstants {
 
     public static final String LDP_NAMESPACE = "http://www.w3.org/ns/ldp#";
     public static final Resource CONTAINER = createResource(LDP_NAMESPACE + "Container");
+    public static final Resource DIRECT_CONTAINER = createResource(LDP_NAMESPACE + "DirectContainer");
+    public static final Resource INDIRECT_CONTAINER = createResource(LDP_NAMESPACE + "IndirectContainer");
+
     public static final Property MEMBERSHIP_RESOURCE = createProperty(LDP_NAMESPACE + "membershipResource");
     public static final Property NON_RDF_SOURCE = createProperty(LDP_NAMESPACE + "NonRDFSource");
     public static final Property RDF_SOURCE = createProperty(LDP_NAMESPACE + "RDFSource");

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -29,11 +29,13 @@ import static org.fcrepo.importexport.common.FcrepoConstants.CONTENT_TYPE_HEADER
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.CREATED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.DESCRIBEDBY;
+import static org.fcrepo.importexport.common.FcrepoConstants.DIRECT_CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.EXTERNAL_RESOURCE_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MIME_TYPE;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_SIZE;
 import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.INDIRECT_CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_BY;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_DATE;
 import static org.fcrepo.importexport.common.FcrepoConstants.LDP_NAMESPACE;
@@ -69,9 +71,12 @@ import java.security.NoSuchAlgorithmException;
 import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -305,7 +310,9 @@ public class Importer implements TransferProcess {
         try {
             final Model diskModel = parseStream(new FileInputStream(f));
             final Model repoModel = parseStream(client().get(uri).perform().getBody());
-            final FcrepoResponse response = importContainer(uri, sanitize(diskModel.difference(repoModel)));
+            final FcrepoResponse response = importContainer(uri,
+                                                            sanitize(diskModel.difference(repoModel)),
+                                                            parseHeaders(getHeadersFile(f)));
             if (response.getStatusCode() == 401) {
                 importLogger.error("Error importing {} to {}, 401 Unauthorized", f.getAbsolutePath(), uri);
                 throw new AuthenticationRequiredRuntimeException();
@@ -359,16 +366,7 @@ public class Importer implements TransferProcess {
         }
 
         //parse headers from headers file
-        final Map<String,List<String>> headers;
-
-        try {
-            headers = parseHeaders(getHeadersFile(f));
-        } catch (IOException ex) {
-            importLogger.error(String.format("Error reading/parsing headers file for %1$s - Message: %2$s",
-                f.getAbsolutePath(), ex.getMessage()), ex);
-            throw new RuntimeException(
-                "Error reading or parsing headers file for" + f.getAbsolutePath() + ": " + ex.toString(), ex);
-        }
+        final Map<String,List<String>> headers = parseHeaders(getHeadersFile(f));
 
         //always skip timemaps since they are derived from the mementos they contain.
         if (isTimeMap(headers)) {
@@ -441,7 +439,7 @@ public class Importer implements TransferProcess {
                     }
 
                     logger.info("Importing container {} to {}", f.getAbsolutePath(), destinationUri);
-                    response = importContainer(destinationUri, sanitize(model));
+                    response = importContainer(destinationUri, sanitize(model), headers);
                 }
             }
 
@@ -535,19 +533,25 @@ public class Importer implements TransferProcess {
         return new File(f.getParentFile(), f.getName() + HEADERS_EXTENSION);
     }
 
-    private Map<String, List<String>> parseHeaders(final File headersFile) throws IOException {
+    private Map<String, List<String>> parseHeaders(final File headersFile) {
+        try {
+            if (!headersFile.exists()) {
+                return new HashMap<>();
+            }
 
-        if (!headersFile.exists()) {
-            return new HashMap<>();
+            //converting json to Map
+            final byte[] mapData = Files.readAllBytes(Paths.get(headersFile.toURI()));
+            final ObjectMapper objectMapper = new ObjectMapper();
+            final Map<String, List<String>> headers =
+                objectMapper.readValue(mapData, new TypeReference<HashMap<String, List<String>>>() {
+                });
+            return headers;
+        } catch (IOException ex) {
+            importLogger.error(String.format("Error reading/parsing headers file for %1$s - Message: %2$s",
+                headersFile.getAbsolutePath(), ex.getMessage()), ex);
+            throw new RuntimeException(
+                "Error reading or parsing headers file for" + headersFile.getAbsolutePath() + ": " + ex.toString(), ex);
         }
-
-        //converting json to Map
-        final byte[] mapData = Files.readAllBytes(Paths.get(headersFile.toURI()));
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map<String, List<String>> headers =
-            objectMapper.readValue(mapData, new TypeReference<HashMap<String, List<String>>>() {
-            });
-        return headers;
     }
 
     private Model parseStream(final InputStream in) throws IOException {
@@ -611,17 +615,19 @@ public class Importer implements TransferProcess {
         return contentType.startsWith("message/external-body");
     }
 
-    private FcrepoResponse importContainer(final URI uri, final Model model) throws FcrepoOperationFailedException {
-        final FcrepoResponse response = containerBuilder(uri, model).preferLenient().perform();
+    private FcrepoResponse importContainer(final URI uri, final Model model, final Map<String,List<String>> headers)
+        throws FcrepoOperationFailedException {
+        final FcrepoResponse response = containerBuilder(uri, model, headers).preferLenient().perform();
         if (response.getStatusCode() == 410 && config.overwriteTombstones()) {
             deleteTombstone(response);
-            return containerBuilder(uri, model).preferLenient().perform();
+            return containerBuilder(uri, model, headers).preferLenient().perform();
         } else {
             return response;
         }
     }
 
-    private PutBuilder containerBuilder(final URI uri, final Model model) throws FcrepoOperationFailedException {
+    private PutBuilder containerBuilder(final URI uri, final Model model, final Map<String,List<String>> headers)
+        throws FcrepoOperationFailedException {
         PutBuilder builder = client().put(uri)
                                      .body(modelToStream(model), config.getRdfLanguage())
                                      .ifUnmodifiedSince(currentTimestamp());
@@ -632,7 +638,24 @@ public class Importer implements TransferProcess {
             logger.debug("Using Bagit checksum ({}) for file ({})", checksum, containerFile.getPath());
             builder = builder.digest(checksum);
         }
+
+        addContainerLinkType(builder, headers);
         return builder;
+    }
+
+    private void addContainerLinkType(final PutBuilder builder, final Map<String, List<String>> headers) {
+        final Set<String> addableLinkTypes = new HashSet<>(Arrays.asList(DIRECT_CONTAINER.getURI(),
+                                                                         INDIRECT_CONTAINER.getURI()));
+        headers.entrySet().stream().filter(entry -> entry.getKey().equals("Link"))
+            .flatMap(entry -> entry.getValue().stream())
+            .forEach(linkstr -> {
+                final Link link = Link.valueOf(linkstr);
+                if (link.getRel().equals("type")) {
+                    if (addableLinkTypes.contains(link.getUri().toString())) {
+                        builder.addHeader("Link", linkstr);
+                    }
+                }
+            });
     }
 
     private String currentTimestamp() {

--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -142,8 +142,14 @@ public abstract class AbstractResourceIT {
     }
 
     protected FcrepoResponse createBody(final URI uri, final String body, final String contentType)
-            throws FcrepoOperationFailedException {
-        return createBody(uri, new ByteArrayInputStream(body.getBytes()), contentType, null);
+        throws FcrepoOperationFailedException {
+        return createBody(uri, body, contentType, null);
+    }
+
+    protected FcrepoResponse createBody(final URI uri, final String body, final String contentType,
+                                        final Map<String, String> headers)
+        throws FcrepoOperationFailedException {
+        return createBody(uri, new ByteArrayInputStream(body.getBytes()), contentType, headers);
     }
 
     protected FcrepoResponse createBody(final URI uri, final InputStream stream, final String contentType)
@@ -176,9 +182,14 @@ public abstract class AbstractResourceIT {
         return response;
     }
 
-    protected FcrepoResponse createTurtle(final URI uri, final String body)
+    protected FcrepoResponse createTurtle(final URI uri, final String body, final Map<String,String> headers)
             throws FcrepoOperationFailedException {
-        return createBody(uri, body, "text/turtle");
+        return createBody(uri, body, "text/turtle", headers);
+    }
+
+    protected FcrepoResponse createTurtle(final URI uri, final String body)
+        throws FcrepoOperationFailedException {
+        return createTurtle(uri, body, null);
     }
 
     protected InputStream insertTitle(final String title) {

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -23,7 +23,9 @@ import java.io.FileInputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
@@ -226,7 +228,6 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(model.contains(date1, createProperty(EDM_END), dateLiteral("2013-12-31T23:59:59Z")));
     }
 
-    @Ignore
     @Test
     public void testRoundtripDirectContainer() throws Exception {
         final String baseURI = serverAddress + UUID.randomUUID();
@@ -235,12 +236,15 @@ public class RoundtripIT extends AbstractResourceIT {
         final URI part1 = URI.create(baseURI + "/res1/parts/part1");
 
 
-        final String partsTurtle = "<> a <" + LDP_DIRECT_CONTAINER + "> ; "
-            + "<" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
+        final String partsTurtle = " <> <" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
             + "<" + LDP_MEMBERSHIP_RESOURCE + "> <" +  res1.toString() + "> .";
 
         create(res1);
-        createTurtle(parts, partsTurtle);
+
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("Link", "<" + LDP_DIRECT_CONTAINER + ">; rel=\"type\"");
+
+        createTurtle(parts, partsTurtle, headers);
         create(part1);
 
         roundtrip(URI.create(baseURI), true);
@@ -264,7 +268,6 @@ public class RoundtripIT extends AbstractResourceIT {
         assertFalse(model3.contains(parent, createProperty(DCTERMS_HAS_PART), member));
     }
 
-    @Ignore
     @Test
     public void testRoundtripIndirectContainer() throws Exception {
         final String baseURI = serverAddress + UUID.randomUUID();
@@ -273,8 +276,7 @@ public class RoundtripIT extends AbstractResourceIT {
         final URI parts = URI.create(baseURI + "/res2/parts");
         final URI proxy = URI.create(baseURI + "/res2/parts/proxy1");
 
-        final String partsTurtle = "<> a <" + LDP_INDIRECT_CONTAINER + "> ; "
-            + "<" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
+        final String partsTurtle = "<> <" + LDP_HAS_MEMBER_RELATION + "> <" + DCTERMS_HAS_PART + "> ; "
             + "<" + LDP_MEMBERSHIP_RESOURCE + "> <" +  res2.toString() + "> ; "
             + "<" + LDP_INSERTED_CONTENT_RELATION + "> <" + ORE_PROXY_FOR + "> .";
 
@@ -283,7 +285,9 @@ public class RoundtripIT extends AbstractResourceIT {
 
         create(res1);
         create(res2);
-        createTurtle(parts, partsTurtle);
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("Link", "<" + LDP_INDIRECT_CONTAINER + ">; rel=\"type\"");
+        createTurtle(parts, partsTurtle, headers);
         createTurtle(proxy, proxyTurtle);
 
         roundtrip(URI.create(baseURI), true);


### PR DESCRIPTION
… 1.0.

Resolves: https://jira.duraspace.org/browse/FCREPO-3017
***********************
Aligns the importing of direct and indirect containers with the Fedora API specification and makes minor updates to the direct and indirect container integration tests.   On import we are now passing the DirectContainer and IndirectContainer  link headers as part of the PUT operation.  The functionality is covered by integration tests.