### PR TITLE
Aligns external content handling in importer with the Fedora API Spec…

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -52,7 +52,6 @@ public interface TransferProcess {
 
     final static String IMPORT_EXPORT_LOG_PREFIX = "org.fcrepo.importexport.audit";
     final static String BAGIT_CHECKSUM_DELIMITER = "  ";
-    final static String STATUS_CODE_HEADER_KEY = "Http-Status-Code";
 
     // Used only to load patched RDF writers
     RdfWriterHelper notUsed = new RdfWriterHelper();

--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -52,6 +52,7 @@ public interface TransferProcess {
 
     final static String IMPORT_EXPORT_LOG_PREFIX = "org.fcrepo.importexport.audit";
     final static String BAGIT_CHECKSUM_DELIMITER = "  ";
+    final static String STATUS_CODE_HEADER_KEY = "Http-Status-Code";
 
     // Used only to load patched RDF writers
     RdfWriterHelper notUsed = new RdfWriterHelper();

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -399,7 +399,12 @@ public class Exporter implements TransferProcess {
     }
 
     void writeHeadersFile(final FcrepoResponse response, final File file) throws IOException {
-        final String json = new ObjectMapper().writeValueAsString(response.getHeaders());
+
+        final Map<String, List<String>> headers = response.getHeaders();
+        //add status code header:
+        final Map<String, List<String>> headersWithStatus = new HashMap<>(headers);
+        headersWithStatus.put(STATUS_CODE_HEADER_KEY, Arrays.asList(response.getStatusCode() + ""));
+        final String json = new ObjectMapper().writeValueAsString(headersWithStatus);
         try (final FileWriter writer = new FileWriter(file)) {
             writer.write(json);
         }
@@ -501,7 +506,7 @@ public class Exporter implements TransferProcess {
 
         // Resolve the timemap endpoint for this resource
         final URI timemapURI;
-        try (FcrepoResponse response = client().head(uri).perform()) {
+        try (FcrepoResponse response = client().head(uri).disableRedirects().perform()) {
             checkValidResponse(response, uri, config.getUsername());
             if (response.getLinkHeaders("type").stream()
                 .filter(x -> x.toString().equals(MEMENTO.getURI()))

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -401,10 +401,7 @@ public class Exporter implements TransferProcess {
     void writeHeadersFile(final FcrepoResponse response, final File file) throws IOException {
 
         final Map<String, List<String>> headers = response.getHeaders();
-        //add status code header:
-        final Map<String, List<String>> headersWithStatus = new HashMap<>(headers);
-        headersWithStatus.put(STATUS_CODE_HEADER_KEY, Arrays.asList(response.getStatusCode() + ""));
-        final String json = new ObjectMapper().writeValueAsString(headersWithStatus);
+        final String json = new ObjectMapper().writeValueAsString(headers);
         try (final FileWriter writer = new FileWriter(file)) {
             writer.write(json);
         }

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -33,7 +33,6 @@ import static org.fcrepo.importexport.common.FcrepoConstants.DIRECT_CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.EXTERNAL_RESOURCE_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.importexport.common.FcrepoConstants.HAS_MIME_TYPE;
-import static org.fcrepo.importexport.common.FcrepoConstants.HAS_SIZE;
 import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
 import static org.fcrepo.importexport.common.FcrepoConstants.INDIRECT_CONTAINER;
 import static org.fcrepo.importexport.common.FcrepoConstants.LAST_MODIFIED_BY;
@@ -273,7 +272,7 @@ public class Importer implements TransferProcess {
                                 relatedResources.add(URI.create(uri));
 
                                 logger.debug("Added related resource {}", uri);
-                            } else if ((fileForBinaryURI(resURI, false).exists() || fileForBinaryURI(resURI, true)
+                            } else if ((fileForBinaryURI(resURI).exists() || fileForBinaryURI(resURI)
                                     .exists())) {
                                 importedResources.add(URI.create(uri));
 
@@ -568,7 +567,8 @@ public class Importer implements TransferProcess {
     private FcrepoResponse importBinary(final URI binaryURI, final Model model)
             throws FcrepoOperationFailedException, IOException {
         final String contentType = model.getProperty(createResource(binaryURI.toString()), HAS_MIME_TYPE).getString();
-        final File binaryFile =  fileForBinaryURI(binaryURI, external(contentType));
+        final File binaryFile =  fileForBinaryURI(binaryURI);
+
         final FcrepoResponse binaryResponse = binaryBuilder(binaryURI, binaryFile, contentType, model).perform();
         if (binaryResponse.getStatusCode() == 201 || binaryResponse.getStatusCode() == 204) {
             logger.info("Imported binary: {}", binaryURI);
@@ -590,16 +590,22 @@ public class Importer implements TransferProcess {
 
     private PutBuilder binaryBuilder(final URI binaryURI, final File binaryFile, final String contentType,
             final Model model) throws FcrepoOperationFailedException, IOException {
-        final InputStream contentStream;
-        if (external(contentType)) {
-            contentStream = new ByteArrayInputStream(new byte[]{});
+        final Map<String,List<String>> headers = parseHeaders(getHeadersFile(binaryFile));
+        final String externalContentLocation = getExternalContentLocation(headers);
+        final boolean external = externalContentLocation != null;
+
+        PutBuilder builder = client().put(binaryURI)
+                                     .filename(null);
+
+        if (external) {
+            final int statusCode = Integer.parseInt(getFirstByKey(headers, STATUS_CODE_HEADER_KEY));
+            final String handling = statusCode < 300 ? "proxy" : "redirect";
+            builder.addHeader("Link", "<" + externalContentLocation + ">; " +
+                "type=\"" + contentType + "\"; handling=\"" + handling + "\"; " +
+                "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"");
         } else {
-            contentStream = new FileInputStream(binaryFile);
-        }
-        PutBuilder builder = client().put(binaryURI).filename(null)
-                                     .body(contentStream, contentType)
-                                     .ifUnmodifiedSince(currentTimestamp());
-        if (!external(contentType)) {
+            builder.body(new FileInputStream(binaryFile), contentType).ifUnmodifiedSince(currentTimestamp());
+
             if (sha1FileMap != null) {
                 // Use the bagIt checksum
                 final String checksum = sha1FileMap.get(binaryFile.getAbsolutePath());
@@ -613,8 +619,8 @@ public class Importer implements TransferProcess {
         return builder;
     }
 
-    private boolean external(final String contentType) {
-        return contentType.startsWith("message/external-body");
+    private String getExternalContentLocation(final Map<String,List<String>> headers) {
+        return  getFirstByKey(headers, "Content-Location");
     }
 
     private FcrepoResponse importContainer(final URI uri, final Model model, final Map<String,List<String>> headers)
@@ -705,7 +711,6 @@ public class Importer implements TransferProcess {
                     || s.getPredicate().equals(DESCRIBEDBY)
                     || s.getPredicate().equals(CONTAINS)
                     || s.getPredicate().equals(HAS_MESSAGE_DIGEST)
-                    || s.getPredicate().equals(HAS_SIZE)
                     || (s.getPredicate().equals(RDF_TYPE) && forbiddenType(s.getResource()))) {
                 remove.add(s);
             } else if (s.getObject().isResource()) {
@@ -759,7 +764,7 @@ public class Importer implements TransferProcess {
 
         final FcrepoResponse response;
         final ByteArrayInputStream emptyStream = new ByteArrayInputStream(new byte[]{});
-        if (fileForBinaryURI(uri, false).exists() || fileForBinaryURI(uri, true).exists()) {
+        if (fileForBinaryURI(uri).exists()) {
             response = client().put(uri).body(emptyStream).perform();
         } else if (fileForContainerURI(uri).exists()) {
             response = client().put(uri).body(emptyStream, "text/turtle").perform();
@@ -812,13 +817,15 @@ public class Importer implements TransferProcess {
         return (base.endsWith("/")) ? base : base + "/";
     }
 
-    private File fileForBinaryURI(final URI uri, final boolean external) {
-        if (external) {
-            return fileForExternalResources(uri, config.getSourcePath(), config.getDestinationPath(),
+    private File fileForBinaryURI(final URI uri) {
+        final File file = fileForExternalResources(uri, config.getSourcePath(), config.getDestinationPath(),
                     config.getBaseDirectory());
+
+        if (file.exists()) {
+            return file;
         } else {
             return fileForBinary(uri, config.getSourcePath(), config.getDestinationPath(),
-                    config.getBaseDirectory());
+                config.getBaseDirectory());
         }
     }
 

--- a/src/test/java/org/fcrepo/importexport/importer/ImporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/importer/ImporterTest.java
@@ -235,7 +235,6 @@ public class ImporterTest {
         final Importer importer = new Importer(externalResourceArgs, clientBuilder);
         importer.run();
         verify(client).put(externalResourceURI);
-        verify(externalResourceBuilder).body(isA(InputStream.class), eq("message/external-body"));
         verify(client).put(externalResourceDescriptionURI);
     }
 

--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -87,7 +87,9 @@ public abstract class AbstractResourceIT {
 
     static final String PASSWORD = "password";
 
-    static final String serverAddress = "http://" + HOSTNAME + ":" + SERVER_PORT + "/fcrepo/rest/";
+    static final String ROOT_PATH = "fcrepo/rest/";
+
+    static final String serverAddress = "http://" + HOSTNAME + ":" + SERVER_PORT + "/" + ROOT_PATH;
 
     static final String TARGET_DIR = System.getProperty("project.build.directory");
 

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -127,9 +127,9 @@ public class ExporterIT extends AbstractResourceIT {
 
         // verify that files exist and contain expected content
         final File exportDir = config.getBaseDirectory();
-        final File containerFile = new File(exportDir, "fcrepo/rest/" + uuid + config.getRdfExtension());
-        final File binaryFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1.binary");
-        final File descFile = new File(exportDir, "fcrepo/rest/" + uuid + "/file1/fcr%3Ametadata"
+        final File containerFile = new File(exportDir, ROOT_PATH + uuid + config.getRdfExtension());
+        final File binaryFile = new File(exportDir, ROOT_PATH + uuid + "/file1.binary");
+        final File descFile = new File(exportDir, ROOT_PATH + uuid + "/file1/fcr%3Ametadata"
                 + config.getRdfExtension());
 
         assertTrue(containerFile.exists() && containerFile.isFile());

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -416,16 +416,13 @@ public class RoundtripIT extends AbstractResourceIT {
     public void testRoundtripExternalRedirect() throws Exception {
         final UUID uuid = UUID.randomUUID();
         final String baseURI = serverAddress + uuid;
-        final URI res1 = URI.create(baseURI);
         final URI file1 = URI.create(baseURI + "/file1");
 
-        final Resource container = createResource(res1.toString());
         final Resource binary = createResource(file1.toString());
 
         final String file1patch = "insert data { "
             + "<" + file1.toString() + "> <" + SKOS_PREFLABEL + "> \"original version\" . }";
 
-        create(res1);
         final URI externalURI = URI.create("http://www.example.com/file1");
         final FcrepoResponse resp = client.put(file1)
             .externalContent(externalURI, "text/plain", "redirect")
@@ -437,16 +434,11 @@ public class RoundtripIT extends AbstractResourceIT {
 
         // verify that files exist and contain expected content
         final File exportDir = config.getBaseDirectory();
-        final File containerFile = new File(exportDir, ROOT_PATH + uuid + config.getRdfExtension());
         final File binaryFile = new File(exportDir, ROOT_PATH + uuid + "/file1.external");
         final File binaryFileHeaders = new File(exportDir, ROOT_PATH + uuid + "/file1.external.headers");
 
         final File descFile = new File(exportDir, ROOT_PATH + uuid + "/file1/fcr%3Ametadata"
                 + config.getRdfExtension());
-
-        assertTrue(containerFile.exists() && containerFile.isFile());
-        final Model contModel = loadModel(containerFile.getAbsolutePath());
-        assertTrue(contModel.contains(container, RDF_TYPE, CONTAINER));
 
         assertTrue(binaryFile.exists() && binaryFile.isFile());
         assertEquals("", IOUtils.toString(new FileInputStream(binaryFile)));
@@ -460,7 +452,6 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(descModel.contains(binary, createProperty(EBU_HAS_MIME_TYPE), "text/plain"));
 
         // verify that the resources exist in the repository
-        assertTrue(exists(res1));
         assertTrue(exists(file1));
         final FcrepoResponse redirResp = client.get(file1).disableRedirects().perform();
         assertEquals(307, redirResp.getStatusCode());

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -44,7 +44,6 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.importexport.common.Config;
 import org.fcrepo.importexport.exporter.Exporter;
 import org.fcrepo.importexport.importer.Importer;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -428,12 +427,9 @@ public class RoundtripIT extends AbstractResourceIT {
 
         create(res1);
         final URI externalURI = URI.create("http://www.example.com/file1");
-        final String externalContent = "<" + externalURI + ">; " +
-                                       "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; " +
-                                        "handling=\"redirect\";type=\"text/plain\"";
-        final Map<String,String> headers = new HashMap<>();
-        headers.put("Link", externalContent);
-        final FcrepoResponse resp = createBody(file1, new ByteArrayInputStream(new byte[]{}), "text/plain", headers);
+        final FcrepoResponse resp = client.put(file1)
+            .externalContent(externalURI, "text/plain", "redirect")
+                .perform();
         final URI file1desc = resp.getLinkHeaders("describedby").get(0);
         patch(file1desc, file1patch);
 
@@ -500,12 +496,10 @@ public class RoundtripIT extends AbstractResourceIT {
 
         create(res1);
         final URI externalURI = localBinaryFile.toURI();
-        final String externalContent = "<" + externalURI + ">; " +
-            "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; " +
-            "handling=\"proxy\";type=\"text/plain\"";
-        final Map<String, String> headers = new HashMap<>();
-        headers.put("Link", externalContent);
-        final FcrepoResponse resp = createBody(file1, new ByteArrayInputStream(new byte[] {}), "text/plain", headers);
+        final FcrepoResponse resp = client.put(file1)
+                                          .externalContent(externalURI, "text/plain", "proxy")
+                                          .perform();
+
         final URI file1desc = resp.getLinkHeaders("describedby").get(0);
         patch(file1desc, file1patch);
 

--- a/src/test/resources/sample/external/rest/ext1.external.headers
+++ b/src/test/resources/sample/external/rest/ext1.external.headers
@@ -1,4 +1,4 @@
 {
-    "Http-Status-Code": ["307"],
+    "Location": ["http://example.org:9999/rest/ext1"],
     "Content-Location": ["http://example.org:9999/rest/ext1"]
 }

--- a/src/test/resources/sample/external/rest/ext1.external.headers
+++ b/src/test/resources/sample/external/rest/ext1.external.headers
@@ -1,0 +1,4 @@
+{
+    "Http-Status-Code": ["307"],
+    "Content-Location": ["http://example.org:9999/rest/ext1"]
+}


### PR DESCRIPTION
… 1.0.

Resolves: https://jira.duraspace.org/browse/FCREPO-3017

****************
With this PR,  5.x round-tripping of external content  now works.  I've created two new integration tests that cover both "redirect" and "proxy" handling methods for external content.

To test this manually: 

1.  Start up a clean repo
2. create a resource that references external content using the redirect method.
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/redirect  -H "Link: <https://www.lyrasis.org/SiteAssets/lyrasis.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"redirect\"; type=\"image/png\""

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/redirect -i
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/redirect/fcr:metadata -i

```
3. create a resource that references local external content using the proxy method.
```
# create text file at /path/to/local/file/test.txt first
echo "test" > /tmp/test.txt

curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-local  -H "Link: <file:/tmp/test.txt>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" -i

curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-local -i
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-local/fcr:metadata -i
```
4. create a resource that references remote external content using the proxy method.
```
curl -X PUT -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-remote  -H "Link: <https://www.lyrasis.org/SiteAssets/lyrasis.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" -i

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-remote -i
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-remote/fcr:metadata -i

```
5. do an export
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode export --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir -u fedoraAdmin:fedoraAdmin
```
6. start a fresh repo
7. do an import
```
java -jar ~/code/fcrepo-import-export/target/fcrepo-import-export-0.4.0-SNAPSHOT.jar  --mode import --predicates "http://www.w3.org/ns/ldp#contains" --resource "http://localhost:8080/rest" --versions --binaries --rdfLang "text/turtle" --dir export-dir -u fedoraAdmin:fedoraAdmin
```
8. verify that both resources are returning the same headers and bodies.
```
curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/redirect -i
curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/redirect/fcr:metadata -i

curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-local -i
curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-local/fcr:metadata -i

curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-remote -i
curl  -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy-remote/fcr:metadata -i

```