### PR TITLE
Update to allow build and run with Java 11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
+
 before_install:
   - "echo $JAVA_OPTS"
   - "export JAVA_OPTS=-Xmx512m"
@@ -11,5 +13,3 @@ script:
   - mvn javadoc:jar
   - mvn javadoc:test-aggregate
 
-notifications:
-irc: "irc.freenode.org#fcrepo"

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.java.source>1.8</project.java.source>
     <!-- We do NOT want to rely on a snapshot dependency, but changes were 
       necessary in the fcrepo-java-client that haven't made it into a stable release. -->
     <fcrepo.version>5.1.0</fcrepo.version>
@@ -228,6 +229,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>${project.java.source}</source>
+          <linksource>true</linksource>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <bagit.version>5.0.0-BETA</bagit.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <httpclient.version>4.3.6</httpclient.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.10.1</jackson.version>
     <jena.version>3.1.1</jena.version>
     <jena.patch.version>4.7.2</jena.patch.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
JIRA: https://jira.lyrasis.org/browse/FCREPO-3173

Also updates jackson-databind and switches oracle 8 for openjdk 8 adds openjdk 11.

@fcrepo4-labs/committers @mikejritter 