### PR TITLE
Support export for the BeyondTheRepository BagIt profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,19 @@ java -jar fcrepo-import-export.jar --mode import --resource http://example.org:8
 ```
 
 
-Running the import/export utility with a BagIt support
+Running the import/export utility with BagIt support
 ------------------------------------------------------
 
-You can export a [BagIt](https://tools.ietf.org/html/draft-kunze-bagit-14) bag from a Fedora repository based on a [BagIt Profile](https://github.com/ruebot/bagit-profiles/), and user supplied metadata for tag files can be provided with a Yaml file.
+You can export a [BagIt](https://tools.ietf.org/html/draft-kunze-bagit-14) bag from a Fedora repository based on a [BagIt Profile](https://github.com/ruebot/bagit-profiles/). User supplied metadata for tag files can be provided with a Yaml file specified by the `-G` or `--bag-config` option.
+
+To enable a bag profile, use the `-g` or `--bag-profile` option. The import/export utility currently supports the following bag profiles:
+
+* [default](https://fedora.info/bagprofile/default.json)
+* [aptrust](https://fedora.info/bagprofile/aptrust.json)
+* [metaarchive](https://fedora.info/bagprofile/metaarchive.json)
+* [perseids](https://w3id.org/ro/bagit/profile)
+* [beyondtherepository](https://fedora.info/bagprofile/beyondtherepository.json)
+
 
 For example, to export all of the resources from a Fedora repository at `http://localhost:8080/rest/` in a BagIt bag using the default profile and user supplied metadata for tag files:
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ You can export a [BagIt](https://tools.ietf.org/html/draft-kunze-bagit-14) bag f
 
 To enable a bag profile, use the `-g` or `--bag-profile` option. The import/export utility currently supports the following bag profiles:
 
-* [default](https://fedora.info/bagprofile/default.json)
-* [aptrust](https://fedora.info/bagprofile/aptrust.json)
-* [metaarchive](https://fedora.info/bagprofile/metaarchive.json)
-* [perseids](https://w3id.org/ro/bagit/profile)
-* [beyondtherepository](https://fedora.info/bagprofile/beyondtherepository.json)
+* [default](src/main/resources/profiles/default.json)
+* [aptrust](src/main/resources/profiles/aptrust.json)
+* [metaarchive](src/main/resources/profiles/metaarchive.json)
+* [perseids](src/main/resources/profiles/perseids.json)
+* [beyondtherepository](src/main/resources/profiles/beyondtherepository.json)
 
 
 For example, to export all of the resources from a Fedora repository at `http://localhost:8080/rest/` in a BagIt bag using the default profile and user supplied metadata for tag files:

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -183,7 +183,8 @@ public class ArgParser {
                 .longOpt(BAG_PROFILE_OPTION_KEY).argName("profile")
                 .hasArg(true).numberOfArgs(1).argName("profile")
                 .required(false)
-                .desc("Export and import BagIt bags using profile [default|aptrust]")
+                .desc("Export and import BagIt bags using profile [default|aptrust|metaarchive|perseids|" +
+                      "beyondtherepository]")
                 .build());
 
         configOptions.addOption(Option.builder("G")

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -17,6 +17,18 @@
  */
 package org.fcrepo.importexport.common;
 
+import static org.fcrepo.importexport.common.BagProfileConstants.ACCEPT_BAGIT_VERSION;
+import static org.fcrepo.importexport.common.BagProfileConstants.ACCEPT_SERIALIZATION;
+import static org.fcrepo.importexport.common.BagProfileConstants.ALLOW_FETCH_TXT;
+import static org.fcrepo.importexport.common.BagProfileConstants.BAGIT_PROFILE_INFO;
+import static org.fcrepo.importexport.common.BagProfileConstants.MANIFESTS_ALLOWED;
+import static org.fcrepo.importexport.common.BagProfileConstants.MANIFESTS_REQUIRED;
+import static org.fcrepo.importexport.common.BagProfileConstants.OTHER_INFO;
+import static org.fcrepo.importexport.common.BagProfileConstants.SERIALIZATION;
+import static org.fcrepo.importexport.common.BagProfileConstants.TAG_FILES_ALLOWED;
+import static org.fcrepo.importexport.common.BagProfileConstants.TAG_FILES_REQUIRED;
+import static org.fcrepo.importexport.common.BagProfileConstants.TAG_MANIFESTS_ALLOWED;
+import static org.fcrepo.importexport.common.BagProfileConstants.TAG_MANIFESTS_REQUIRED;
 import static org.fcrepo.importexport.common.FcrepoConstants.BAG_INFO_FIELDNAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -74,20 +86,20 @@ public class BagProfile {
 
         loadProfileInfo(json);
 
-        allowFetch = json.has("Allow-Fetch.txt") ? json.get("Allow-Fetch.txt").asBoolean() : true;
-        serialization = json.has("Serialization") ? json.get("Serialization").asText() : "optional";
+        allowFetch = json.has(ALLOW_FETCH_TXT) ? json.get(ALLOW_FETCH_TXT).asBoolean() : true;
+        serialization = json.has(SERIALIZATION) ? json.get(SERIALIZATION).asText() : "optional";
 
-        acceptedBagItVersions = arrayValues(json, "Accept-BagIt-Version");
-        acceptedSerializations = arrayValues(json, "Accept-Serialization");
+        acceptedBagItVersions = arrayValues(json, ACCEPT_BAGIT_VERSION);
+        acceptedSerializations = arrayValues(json, ACCEPT_SERIALIZATION);
 
-        tagFilesAllowed = arrayValues(json, "Tag-Files-Allowed");
-        tagFilesRequired = arrayValues(json, "Tag-Files-Required");
+        tagFilesAllowed = arrayValues(json, TAG_FILES_ALLOWED);
+        tagFilesRequired = arrayValues(json, TAG_FILES_REQUIRED);
 
-        allowedPayloadAlgorithms = arrayValues(json, "Manifests-Allowed");
-        allowedTagAlgorithms = arrayValues(json, "Tag-Manifests-Allowed");
+        allowedPayloadAlgorithms = arrayValues(json, MANIFESTS_ALLOWED);
+        allowedTagAlgorithms = arrayValues(json, TAG_MANIFESTS_ALLOWED);
 
-        payloadDigestAlgorithms = arrayValues(json, "Manifests-Required");
-        tagDigestAlgorithms = arrayValues(json, "Tag-Manifests-Required");
+        payloadDigestAlgorithms = arrayValues(json, MANIFESTS_REQUIRED);
+        tagDigestAlgorithms = arrayValues(json, TAG_MANIFESTS_REQUIRED);
         if (tagDigestAlgorithms == null) {
             tagDigestAlgorithms = payloadDigestAlgorithms;
         }
@@ -95,20 +107,20 @@ public class BagProfile {
         metadataFields.put(BAG_INFO_FIELDNAME, metadataFields(json, BAG_INFO_FIELDNAME));
         sections.add(BAG_INFO_FIELDNAME);
 
-        if (json.get("Other-Info") != null) {
+        if (json.get(OTHER_INFO) != null) {
             loadOtherTags(json);
         }
     }
 
     private void loadProfileInfo(final JsonNode json) {
-        final JsonNode tag = json.get("BagIt-Profile-Info");
+        final JsonNode tag = json.get(BAGIT_PROFILE_INFO);
         if (tag != null) {
             tag.fields().forEachRemaining(entry -> profileMetadata.put(entry.getKey(), entry.getValue().asText()));
         }
     }
 
     private void loadOtherTags(final JsonNode json) {
-        final JsonNode arrayTags = json.get("Other-Info");
+        final JsonNode arrayTags = json.get(OTHER_INFO);
         if (arrayTags != null && arrayTags.isArray()) {
             arrayTags.forEach(tag -> tag.fieldNames().forEachRemaining(sections::add));
             final Iterator<JsonNode> arrayEntries = arrayTags.elements();

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -174,7 +174,7 @@ public class BagProfile {
 
             final JsonNode repeatedNode = field.get("repeatable");
             if (repeatedNode != null) {
-                repeatable = repeatedNode.asBoolean(true);
+                repeatable = repeatedNode.asBoolean();
             }
 
             final JsonNode recommendedNode = field.get("recommended");
@@ -215,7 +215,6 @@ public class BagProfile {
     public String getSerialization() {
         return serialization;
     }
-
 
     /**
      * Get the supported BagIt versions

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -129,7 +129,7 @@ public class BagProfile {
         final JsonNode values = json.get(key);
 
         if (values == null) {
-            return null;
+            return Collections.emptySet();
         }
 
         final Set<String> results = new HashSet<>();
@@ -150,7 +150,7 @@ public class BagProfile {
         final JsonNode fields = json.get(key);
 
         if (fields == null) {
-            return null;
+            return Collections.emptyMap();
         }
 
         final Map<String, ProfileFieldRule> results = new HashMap<>();

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -157,6 +157,7 @@ public class BagProfile {
         for (final Iterator<String> it = fields.fieldNames(); it.hasNext(); ) {
             // fields to pass to the ProfileFieldRule constructor
             boolean required = false;
+            boolean repeatable = true;
             boolean recommended = false;
             String description = "No description";
             Set<String> values = Collections.emptySet();
@@ -164,10 +165,16 @@ public class BagProfile {
             final String name = it.next();
             final JsonNode field = fields.get(name);
 
-            // read each of the fields for the ProfileFieldRule - required, recommended, description, and values
+            // read each of the fields for the ProfileFieldRule:
+            // required, repeated, recommended, description, and values
             final JsonNode requiredNode = field.get("required");
             if (requiredNode != null && requiredNode.asBoolean()) {
                 required = requiredNode.asBoolean();
+            }
+
+            final JsonNode repeatedNode = field.get("repeatable");
+            if (repeatedNode != null) {
+                repeatable = repeatedNode.asBoolean(true);
             }
 
             final JsonNode recommendedNode = field.get("recommended");
@@ -183,7 +190,7 @@ public class BagProfile {
             final Set<String> readValues = arrayValues(field, "values");
             values = readValues == null ? values : readValues;
 
-            results.put(name, new ProfileFieldRule(required, recommended, description, values));
+            results.put(name, new ProfileFieldRule(required, repeatable, recommended, description, values));
         }
 
         return results;

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
+ * @author mikejritter
  * @author escowles
  * @since 2016-12-12
  */
@@ -70,7 +71,7 @@ public class BagProfile {
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode json = mapper.readTree(in);
 
-        loadProfileInto(json);
+        loadProfileInfo(json);
 
         allowFetch = json.has("Allow-Fetch.txt") ? json.get("Allow-Fetch.txt").asBoolean() : true;
         serialization = json.has("Serialization") ? json.get("Serialization").asText() : "optional";
@@ -98,7 +99,7 @@ public class BagProfile {
         }
     }
 
-    private void loadProfileInto(final JsonNode json) {
+    private void loadProfileInfo(final JsonNode json) {
         final JsonNode tag = json.get("BagIt-Profile-Info");
         if (tag != null) {
             tag.fields().forEachRemaining(entry -> profileMetadata.put(entry.getKey(), entry.getValue().asText()));

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -59,6 +59,7 @@ public class BagProfile {
 
     private Set<String> sections = new HashSet<>();
     private Map<String, Map<String, ProfileFieldRule>> metadataFields = new HashMap<>();
+    private Map<String, String> profileMetadata = new HashMap<>();
 
     /**
      * Default constructor.
@@ -68,6 +69,8 @@ public class BagProfile {
     public BagProfile(final InputStream in) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode json = mapper.readTree(in);
+
+        loadProfileInto(json);
 
         allowFetch = json.has("Allow-Fetch.txt") ? json.get("Allow-Fetch.txt").asBoolean() : true;
         serialization = json.has("Serialization") ? json.get("Serialization").asText() : "optional";
@@ -92,6 +95,13 @@ public class BagProfile {
 
         if (json.get("Other-Info") != null) {
             loadOtherTags(json);
+        }
+    }
+
+    private void loadProfileInto(final JsonNode json) {
+        final JsonNode tag = json.get("BagIt-Profile-Info");
+        if (tag != null) {
+            tag.fields().forEachRemaining(entry -> profileMetadata.put(entry.getKey(), entry.getValue().asText()));
         }
     }
 
@@ -283,7 +293,7 @@ public class BagProfile {
 
     /**
      * Get the required Bag-Info metadata fields.
-     * @return A map of field names to a Set of acceptable values (or null when the values are restricted).
+     * @return A map of field names to a ProfileFieldRule containing acceptance criteria
      */
     public Map<String, ProfileFieldRule> getMetadataFields() {
         return getMetadataFields(BAG_INFO_FIELDNAME);
@@ -306,6 +316,15 @@ public class BagProfile {
      */
     public Set<String> getSectionNames() {
         return sections;
+    }
+
+    /**
+     * Get the BagIt-Profile-Info section describing the BagIt Profile
+     *
+     * @return map of fields names to text descriptions
+     */
+    public Map<String, String> getProfileMetadata() {
+        return profileMetadata;
     }
 
     /**

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -154,7 +154,7 @@ public class BagProfile {
 
         final Map<String, ProfileFieldRule> results = new HashMap<>();
         for (final Iterator<String> it = fields.fieldNames(); it.hasNext(); ) {
-            // fields we set with
+            // fields to pass to the ProfileFieldRule constructor
             boolean required = false;
             boolean recommended = false;
             String description = "No description";
@@ -163,9 +163,7 @@ public class BagProfile {
             final String name = it.next();
             final JsonNode field = fields.get(name);
 
-
-            // not sure if this is exactly what we want but good enough for a first pass
-            // can probably move to BagProfileField constructor imo
+            // read each of the fields for the ProfileFieldRule - required, recommended, description, and values
             final JsonNode requiredNode = field.get("required");
             if (requiredNode != null && requiredNode.asBoolean()) {
                 required = requiredNode.asBoolean();

--- a/src/main/java/org/fcrepo/importexport/common/BagProfile.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfile.java
@@ -22,6 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -333,10 +334,13 @@ public class BagProfile {
      */
     public void validateConfig(final BagConfig config) {
         for (final String section : sections) {
-            if (config.hasTagFile(section.toLowerCase() + ".txt")) {
+            final String tagFile = section.toLowerCase() + ".txt";
+            if (config.hasTagFile(tagFile)) {
                 try {
                     ProfileValidationUtil.validate(section, getMetadataFields(section),
-                        config.getFieldsForTagFile(section.toLowerCase() + ".txt"));
+                        config.getFieldsForTagFile(tagFile));
+
+                    ProfileValidationUtil.validateTagIsAllowed(Paths.get(tagFile), tagFilesAllowed);
                 } catch (ProfileValidationException e) {
                     throw new RuntimeException(e.getMessage(), e);
                 }

--- a/src/main/java/org/fcrepo/importexport/common/BagProfileConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagProfileConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.common;
+
+public abstract class BagProfileConstants {
+    public static final String ALLOW_FETCH_TXT = "Allow-Fetch.txt";
+    public static final String SERIALIZATION = "Serialization";
+    public static final String ACCEPT_BAGIT_VERSION = "Accept-BagIt-Version";
+    public static final String ACCEPT_SERIALIZATION = "Accept-Serialization";
+    public static final String TAG_FILES_ALLOWED = "Tag-Files-Allowed";
+    public static final String TAG_FILES_REQUIRED = "Tag-Files-Required";
+    public static final String MANIFESTS_ALLOWED = "Manifests-Allowed";
+    public static final String TAG_MANIFESTS_ALLOWED = "Tag-Manifests-Allowed";
+    public static final String MANIFESTS_REQUIRED = "Manifests-Required";
+    public static final String TAG_MANIFESTS_REQUIRED = "Tag-Manifests-Required";
+    public static final String BAGIT_PROFILE_INFO = "BagIt-Profile-Info";
+    public static final String OTHER_INFO = "Other-Info";
+}

--- a/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
@@ -81,4 +81,19 @@ public class ProfileFieldRule {
     public Set<String> getValues() {
         return values;
     }
+
+    /**
+     * String representation of a ProfileFieldRule
+     *
+     * @return the string representation
+     */
+    @Override
+    public String toString() {
+        return "ProfileFieldRule{" +
+               "required=" + required +
+               ", recommended=" + recommended +
+               ", description='" + description + '\'' +
+               ", values=" + values +
+               '}';
+    }
 }

--- a/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
@@ -20,7 +20,9 @@ package org.fcrepo.importexport.common;
 import java.util.Set;
 
 /**
- *
+ * Rules which can be applied to the Bag-Info and Other-Info sections of a Bag Profile. Currently supports the
+ * parameters specified in version 1.3.0 of the bagit-profiles specification, in addition to the recommended parameter
+ * which is brought in from the Beyond the Repository bagit specification.
  *
  * @author mikejritter
  * @since 2020-01-20

--- a/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.common;
+
+import java.util.Set;
+
+/**
+ *
+ *
+ * @author mikejritter
+ * @since 2020-01-20
+ */
+public class ProfileFieldRule {
+
+    private final boolean required;
+    private final boolean recommended;
+    private final String description;
+    private final Set<String> values;
+
+    /**
+     * Constructor for a ProfileFieldRule. Takes the 4 possible json fields from a BagIt Profile *-Info field.
+     *
+     * @param required boolean value stating if this rule is required
+     * @param recommended boolean value stating if this rule is recommended
+     * @param description a text description of this rule
+     * @param values a set of string values which a field is allowed to be set to
+     */
+    public ProfileFieldRule(final boolean required,
+                            final boolean recommended,
+                            final String description,
+                            final Set<String> values) {
+        this.required = required;
+        this.recommended = recommended;
+        this.description = description;
+        this.values = values;
+    }
+
+    /**
+     *
+     * @return if the field for this rule is required to exist
+     */
+    public boolean isRequired() {
+        return required;
+    }
+
+    /**
+     *
+     * @return if the field for this rule is recommended to exist
+     */
+    public boolean isRecommended() {
+        return recommended;
+    }
+
+    /**
+     *
+     * @return the description of this rule
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     *
+     * @return the allowed values for fields matching this rule
+     */
+    public Set<String> getValues() {
+        return values;
+    }
+}

--- a/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public class ProfileFieldRule {
 
     private final boolean required;
+    private final boolean repeatable;
     private final boolean recommended;
     private final String description;
     private final Set<String> values;
@@ -36,15 +37,18 @@ public class ProfileFieldRule {
      * Constructor for a ProfileFieldRule. Takes the 4 possible json fields from a BagIt Profile *-Info field.
      *
      * @param required boolean value stating if this rule is required
+     * @param repeatable boolean value allowing a field to be repeated
      * @param recommended boolean value stating if this rule is recommended
      * @param description a text description of this rule
      * @param values a set of string values which a field is allowed to be set to
      */
     public ProfileFieldRule(final boolean required,
+                            final boolean repeatable,
                             final boolean recommended,
                             final String description,
                             final Set<String> values) {
         this.required = required;
+        this.repeatable = repeatable;
         this.recommended = recommended;
         this.description = description;
         this.values = values;
@@ -56,6 +60,14 @@ public class ProfileFieldRule {
      */
     public boolean isRequired() {
         return required;
+    }
+
+    /**
+     *
+     * @return if the field is allowed to be repeated
+     */
+    public boolean isRepeatable() {
+        return repeatable;
     }
 
     /**

--- a/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileFieldRule.java
@@ -104,10 +104,10 @@ public class ProfileFieldRule {
     @Override
     public String toString() {
         return "ProfileFieldRule{" +
-               "required=" + required +
-               ", recommended=" + recommended +
-               ", description='" + description + '\'' +
-               ", values=" + values +
-               '}';
+               "\nrequired=" + required +
+               ",\nrecommended=" + recommended +
+               ",\ndescription='" + description + '\'' +
+               ",\nvalues=" + values +
+               "\n}";
     }
 }

--- a/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 /**
  * Utility methods for validating profiles.
  *
+ * @author mikejritter
  * @author dbernstein
  * @since Dec 14, 2016
  */

--- a/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
@@ -49,6 +49,7 @@ public class ProfileValidationUtil {
     protected static final Set<String> SYSTEM_GENERATED_FIELD_NAMES =
             new HashSet<>(Arrays.asList("Bagging-Date",
                                         "Bag-Size",
+                                        "Bag-Count",
                                         "Payload-Oxum",
                                         "BagIt-Profile-Identifier"));
 

--- a/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
@@ -122,7 +122,7 @@ public class ProfileValidationUtil {
 
             boolean match = false;
             for (String allowedTag : allowedTags) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + allowedTag);
+                final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + allowedTag);
 
                 if (matcher.matches(tag)) {
                     match = true;

--- a/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
+++ b/src/main/java/org/fcrepo/importexport/common/ProfileValidationUtil.java
@@ -44,7 +44,8 @@ public class ProfileValidationUtil {
     protected static final Set<String> SYSTEM_GENERATED_FIELD_NAMES =
             new HashSet<>(Arrays.asList("Bagging-Date",
                                         "Bag-Size",
-                                        "Payload-Oxum"));
+                                        "Payload-Oxum",
+                                        "BagIt-Profile-Identifier"));
 
     private ProfileValidationUtil() {
     }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -111,6 +111,7 @@ public class Exporter implements TransferProcess {
     private URI containerURI;
     private URI rdfSourceURI;
     private BagWriter bag;
+    private String bagProfileId;
     private MessageDigest sha1 = null;
     private MessageDigest sha256 = null;
     private MessageDigest md5 = null;
@@ -166,6 +167,10 @@ public class Exporter implements TransferProcess {
 
                 //enforce default metadata
                 bagProfile.validateConfig(bagConfig);
+                final Map<String, String> profileMetadata = bagProfile.getProfileMetadata();
+
+                // assume this is already valid?
+                bagProfileId = profileMetadata.get("BagIt-Profile-Identifier");
 
                 // setup bag
                 final File bagdir = config.getBaseDirectory().getParentFile();
@@ -253,6 +258,7 @@ public class Exporter implements TransferProcess {
 
     private Map<String, String> bagTechMetadata() {
         final Map<String, String> metadata = new HashMap<>();
+        metadata.put("BagIt-Profile-Identifier", bagProfileId);
         metadata.put("Bag-Size", byteCountToDisplaySize(successBytes.longValue()));
         metadata.put("Payload-Oxum", successBytes.toString() + "." + successCount.toString());
         metadata.put("Bagging-Date", dateFormat.format(new Date()));

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -83,6 +83,7 @@ import org.fcrepo.client.FcrepoResponse;
 import org.fcrepo.client.GetBuilder;
 import org.fcrepo.importexport.common.BagConfig;
 import org.fcrepo.importexport.common.BagProfile;
+import org.fcrepo.importexport.common.ProfileFieldRule;
 import org.fcrepo.importexport.common.BagWriter;
 import org.fcrepo.importexport.common.Config;
 import org.fcrepo.importexport.common.ProfileValidationException;
@@ -196,7 +197,7 @@ public class Exporter implements TransferProcess {
         return new BagConfig(bagConfigFile);
     }
 
-    protected void validateProfile(final String profileSection, final Map<String, Set<String>> requiredFields,
+    protected void validateProfile(final String profileSection, final Map<String, ProfileFieldRule> requiredFields,
             final Map<String, String> fields) throws ProfileValidationException {
         ProfileValidationUtil.validate(profileSection, requiredFields, fields);
     }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -170,7 +170,7 @@ public class Exporter implements TransferProcess {
                 bagProfile.validateConfig(bagConfig);
                 final Map<String, String> profileMetadata = bagProfile.getProfileMetadata();
 
-                // assume this is already valid?
+                // the profile identifier must exist per the bagit-profiles spec
                 bagProfileId = profileMetadata.get("BagIt-Profile-Identifier");
 
                 // setup bag

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -95,6 +95,7 @@ import org.slf4j.Logger;
 /**
  * Fedora Export Utility
  *
+ * @author mikejritter
  * @author lsitu
  * @author awoods
  * @author escowles

--- a/src/main/resources/profiles/beyondtherepository.json
+++ b/src/main/resources/profiles/beyondtherepository.json
@@ -3,7 +3,7 @@
     "Source-Organization": "Beyond the Repository Bagit Profile Group",
     "External-Description": "Bagit Profile for Consistent Deposit to Distributed Digital Preservation Services",
     "Version": "0.1",
-    "BagIt-Profile-Identifier": "http://????/???-v0.1.json",
+    "BagIt-Profile-Identifier": "http://fedora.info/bagprofile/beyondtherepository.json",
     "BagIt-Profile-Version": "1.3.0",
     "Contact-Name": "Hope Fully Apersonsname",
     "Contact-Phone": "(we probably don't want this)",

--- a/src/main/resources/profiles/beyondtherepository.json
+++ b/src/main/resources/profiles/beyondtherepository.json
@@ -1,0 +1,72 @@
+{
+  "BagIt-Profile-Info": {
+    "Source-Organization": "Beyond the Repository Bagit Profile Group",
+    "External-Description": "Bagit Profile for Consistent Deposit to Distributed Digital Preservation Services",
+    "Version": "0.1",
+    "BagIt-Profile-Identifier": "http://????/???-v0.1.json",
+    "BagIt-Profile-Version": "1.3.0",
+    "Contact-Name": "Hope Fully Apersonsname",
+    "Contact-Phone": "(we probably don't want this)",
+    "Contact-Email": "fake-email@example.com"
+  },
+  "Bag-Info": {
+    "Source-Organization": {"required": true},
+    "Bagging-Date": {"required": true},
+    "Payload-Oxum": {"required": true},
+    "Organization-Address": {"required": false, "recommended": true},
+    "Contact-Name": {"required": false},
+    "Contact-Phone": {"required": false},
+    "Contact-Email": {"required": false, "recommended": true},
+    "External-Description": {"required": false},
+    "External-Identifier": {"required": false},
+    "Bag-Group-Identifier": {
+      "required": false,
+      "recommended": true,
+      "description": "*Recommended in the case of multiple related bags, otherwise optional"
+    },
+    "Bag-Count": {
+      "required": false,
+      "recommended": true,
+      "description": "*Recommended in the case of multiple related bags, otherwise optional"
+    },
+    "Bag-Size": {"required": false},
+    "Internal-Sender-Identifier": {"required": false, "recommended": true},
+    "Internal-Sender-Description": {"required": false, "recommended": true},
+    "Payload-Identifier": {"required": false},
+    "Bag-Producing-Organization": {
+      "required": false,
+      "recommended": true,
+      "description": "Can be the same as source_organization recommended when not the same as source"
+    }
+  },
+  "Manifests-Required": [],
+  "Manifests-Allowed": [
+    "md5",
+    "sha1",
+    "sha256",
+    "sha512"
+  ],
+  "Allow-Fetch.txt": false,
+  "Serialization": "optional",
+  "Accept-Serialization": [
+    "application/zip",
+    "application/tar",
+    "application/x-tar",
+    "application/gzip",
+    "application/x-gzip",
+    "application/x-7z-compressed"
+  ],
+  "Tag-Manifests-Required": [],
+  "Tag-Manifests-Allowed": [
+    "md5",
+    "sha1",
+    "sha256",
+    "sha512"
+  ],
+  "Tag-Files-Required": [],
+  "Tag-Files-Allowed": ["*"],
+  "Accept-BagIt-Version": [
+    "0.97",
+    "1.0"
+  ]
+}

--- a/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.importexport.common;
 
 import static org.fcrepo.importexport.common.FcrepoConstants.BAG_INFO_FIELDNAME;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -56,6 +57,15 @@ public class BagProfileTest {
 
         assertFalse(
             profile.getSectionNames().stream().filter(t -> !t.equalsIgnoreCase(BAG_INFO_FIELDNAME)).count() > 0);
+
+        assertFalse(profile.isAllowFetch());
+        assertEquals("optional", profile.getSerialization());
+        assertTrue(profile.getAcceptedBagItVersions().contains("0.97"));
+        assertTrue(profile.getAcceptedSerializations().isEmpty());
+        assertTrue(profile.getTagFilesAllowed().isEmpty());
+        assertTrue(profile.getTagFilesRequired().isEmpty());
+        assertTrue(profile.getAllowedTagAlgorithms().isEmpty());
+        assertTrue(profile.getAllowedPayloadAlgorithms().isEmpty());
     }
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
@@ -45,14 +45,15 @@ public class BagProfileTest {
         assertTrue(profile.getTagDigestAlgorithms().contains("sha1"));
         assertFalse(profile.getTagDigestAlgorithms().contains("sha256"));
 
-        assertTrue(profile.getMetadataFields().keySet().contains("Source-Organization"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Organization-Address"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Contact-Name"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Contact-Phone"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Bag-Size"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Bagging-Date"));
-        assertTrue(profile.getMetadataFields().keySet().contains("Payload-Oxum"));
-        assertFalse(profile.getMetadataFields().keySet().contains("Contact-Email"));
+        assertTrue(profile.getMetadataFields().containsKey("Source-Organization"));
+        assertTrue(profile.getMetadataFields().containsKey("Organization-Address"));
+        assertTrue(profile.getMetadataFields().containsKey("Contact-Name"));
+        assertTrue(profile.getMetadataFields().containsKey("Contact-Phone"));
+        assertTrue(profile.getMetadataFields().containsKey("Bag-Size"));
+        assertTrue(profile.getMetadataFields().containsKey("Bagging-Date"));
+        assertTrue(profile.getMetadataFields().containsKey("Payload-Oxum"));
+        assertTrue(profile.getMetadataFields().containsKey("Contact-Email"));
+        assertFalse(profile.getMetadataFields().get("Contact-Email").isRequired());
 
         assertFalse(
             profile.getSectionNames().stream().filter(t -> !t.equalsIgnoreCase(BAG_INFO_FIELDNAME)).count() > 0);
@@ -60,17 +61,18 @@ public class BagProfileTest {
 
     @Test
     public void testExtendedProfile() throws Exception {
+        final String aptrustInfo = "APTrust-Info";
         final File testFile = new File("src/test/resources/profiles/profileWithExtraTags.json");
         final BagProfile profile = new BagProfile(new FileInputStream(testFile));
 
         assertTrue(profile.getSectionNames().stream().filter(t -> !t.equalsIgnoreCase(BAG_INFO_FIELDNAME)).count() > 0);
-        assertTrue(profile.getSectionNames().stream().anyMatch(t -> t.equals("APTrust-Info")));
+        assertTrue(profile.getSectionNames().stream().anyMatch(t -> t.equals(aptrustInfo)));
         assertFalse(profile.getSectionNames().stream().anyMatch(t -> t.equals("Wrong-Tags")));
-        assertTrue(profile.getMetadataFields("APTrust-Info").keySet().contains("Title"));
-        assertTrue(profile.getMetadataFields("APTrust-Info").keySet().contains("Access"));
-        assertTrue(profile.getMetadataFields("APTrust-Info").get("Access").contains("Consortia"));
-        assertTrue(profile.getMetadataFields("APTrust-Info").get("Access").contains("Institution"));
-        assertTrue(profile.getMetadataFields("APTrust-Info").get("Access").contains("Restricted"));
+        assertTrue(profile.getMetadataFields(aptrustInfo).containsKey("Title"));
+        assertTrue(profile.getMetadataFields(aptrustInfo).containsKey("Access"));
+        assertTrue(profile.getMetadataFields(aptrustInfo).get("Access").getValues().contains("Consortia"));
+        assertTrue(profile.getMetadataFields(aptrustInfo).get("Access").getValues().contains("Institution"));
+        assertTrue(profile.getMetadataFields(aptrustInfo).get("Access").getValues().contains("Restricted"));
 
     }
 

--- a/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
@@ -45,14 +45,13 @@ public class BagProfileTest {
         assertTrue(profile.getTagDigestAlgorithms().contains("sha1"));
         assertFalse(profile.getTagDigestAlgorithms().contains("sha256"));
 
-        assertTrue(profile.getMetadataFields().containsKey("Source-Organization"));
-        assertTrue(profile.getMetadataFields().containsKey("Organization-Address"));
-        assertTrue(profile.getMetadataFields().containsKey("Contact-Name"));
-        assertTrue(profile.getMetadataFields().containsKey("Contact-Phone"));
-        assertTrue(profile.getMetadataFields().containsKey("Bag-Size"));
-        assertTrue(profile.getMetadataFields().containsKey("Bagging-Date"));
-        assertTrue(profile.getMetadataFields().containsKey("Payload-Oxum"));
-        assertTrue(profile.getMetadataFields().containsKey("Contact-Email"));
+        assertTrue(profile.getMetadataFields().get("Source-Organization").isRequired());
+        assertTrue(profile.getMetadataFields().get("Organization-Address").isRequired());
+        assertTrue(profile.getMetadataFields().get("Contact-Name").isRequired());
+        assertTrue(profile.getMetadataFields().get("Contact-Phone").isRequired());
+        assertTrue(profile.getMetadataFields().get("Bag-Size").isRequired());
+        assertTrue(profile.getMetadataFields().get("Bagging-Date").isRequired());
+        assertTrue(profile.getMetadataFields().get("Payload-Oxum").isRequired());
         assertFalse(profile.getMetadataFields().get("Contact-Email").isRequired());
 
         assertFalse(

--- a/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.importexport.common;
 
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,6 +101,46 @@ public class ProfileValidationUtilTest {
 
         ProfileValidationUtil.validate("profile-section", rules, fields);
 
+    }
+
+    @Test
+    public void testGlobalTagMatch() throws ProfileValidationException {
+        Set<String> allowedTags = Collections.singleton("**");
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info/test-info.txt"), allowedTags);
+    }
+
+    @Test
+    public void testEmptyListValidates() throws ProfileValidationException {
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), Collections.emptySet());
+    }
+
+    @Test
+    public void testUniqueTagMatch() throws ProfileValidationException {
+        Set<String> allowedTags = Collections.singleton("test-info.txt");
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
+    }
+
+    @Test(expected = ProfileValidationException.class)
+    public void testTagIsNotAllowed() throws ProfileValidationException {
+        Set<String> allowedTags = Collections.singleton("test-tag.txt");
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
+    }
+
+    @Test
+    public void testSubDirectoryMatch() throws ProfileValidationException {
+        Set<String> allowedTags = Collections.singleton("ddp-tags/test-*");
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("ddp-tags/test-info.txt"), allowedTags);
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("ddp-tags/test-extra-info.txt"), allowedTags);
+    }
+
+    @Test
+    public void testTagValidateIgnoresRequired() throws ProfileValidationException {
+        Set<String> allowedTags = Collections.singleton("test-info.txt");
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("bag-info.txt"), allowedTags);
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("bagit.txt"), allowedTags);
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("manifest-md5.txt"), allowedTags);
+        ProfileValidationUtil.validateTagIsAllowed(Paths.get("tagmanifest-sha512.txt"), allowedTags);
     }
 
 }

--- a/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
@@ -46,6 +46,10 @@ public class ProfileValidationUtilTest {
 
     private LinkedHashMap<String, String> fields;
 
+    private static final boolean required = true;
+    private static final boolean repeatable = true;
+    private static final boolean recommended = false;
+
     @Before
     public void setup() {
         rules = new HashMap<>();
@@ -54,7 +58,7 @@ public class ProfileValidationUtilTest {
         set.add("value1");
         set.add("value2");
         set.add("value3");
-        final ProfileFieldRule field = new ProfileFieldRule(true, false, "", set);
+        final ProfileFieldRule field = new ProfileFieldRule(required, repeatable, recommended, "", set);
         rules.put(FIELD1, field);
     }
 
@@ -79,7 +83,8 @@ public class ProfileValidationUtilTest {
     @Test
     public void testMultipleValidationErrorsInOneExceptionMessage() {
         fields.put(FIELD1, "invalidValue");
-        rules.put(FIELD2, new ProfileFieldRule(true, true, "field 2 should fail", Collections.emptySet()));
+        rules.put(FIELD2, new ProfileFieldRule(required, repeatable, recommended,
+                                               "field 2 should fail", Collections.emptySet()));
         fields.put("field3", "any value");
         try {
             ProfileValidationUtil.validate("profile-section", rules, fields);

--- a/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
@@ -105,7 +105,7 @@ public class ProfileValidationUtilTest {
 
     @Test
     public void testGlobalTagMatch() throws ProfileValidationException {
-        Set<String> allowedTags = Collections.singleton("**");
+        final Set<String> allowedTags = Collections.singleton("**");
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info/test-info.txt"), allowedTags);
     }
@@ -117,26 +117,26 @@ public class ProfileValidationUtilTest {
 
     @Test
     public void testUniqueTagMatch() throws ProfileValidationException {
-        Set<String> allowedTags = Collections.singleton("test-info.txt");
+        final Set<String> allowedTags = Collections.singleton("test-info.txt");
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
     }
 
     @Test(expected = ProfileValidationException.class)
     public void testTagIsNotAllowed() throws ProfileValidationException {
-        Set<String> allowedTags = Collections.singleton("test-tag.txt");
+        final Set<String> allowedTags = Collections.singleton("test-tag.txt");
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("test-info.txt"), allowedTags);
     }
 
     @Test
     public void testSubDirectoryMatch() throws ProfileValidationException {
-        Set<String> allowedTags = Collections.singleton("ddp-tags/test-*");
+        final Set<String> allowedTags = Collections.singleton("ddp-tags/test-*");
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("ddp-tags/test-info.txt"), allowedTags);
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("ddp-tags/test-extra-info.txt"), allowedTags);
     }
 
     @Test
     public void testTagValidateIgnoresRequired() throws ProfileValidationException {
-        Set<String> allowedTags = Collections.singleton("test-info.txt");
+        final Set<String> allowedTags = Collections.singleton("test-info.txt");
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("bag-info.txt"), allowedTags);
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("bagit.txt"), allowedTags);
         ProfileValidationUtil.validateTagIsAllowed(Paths.get("manifest-md5.txt"), allowedTags);

--- a/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/ProfileValidationUtilTest.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.importexport.common;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -40,7 +41,7 @@ public class ProfileValidationUtilTest {
 
     private static final String FIELD2 = "field2";
 
-    private Map<String, Set<String>> rules;
+    private Map<String, ProfileFieldRule> rules;
 
     private LinkedHashMap<String, String> fields;
 
@@ -52,7 +53,8 @@ public class ProfileValidationUtilTest {
         set.add("value1");
         set.add("value2");
         set.add("value3");
-        rules.put(FIELD1, set);
+        final ProfileFieldRule field = new ProfileFieldRule(true, false, "", set);
+        rules.put(FIELD1, field);
     }
 
     @Test
@@ -76,7 +78,7 @@ public class ProfileValidationUtilTest {
     @Test
     public void testMultipleValidationErrorsInOneExceptionMessage() {
         fields.put(FIELD1, "invalidValue");
-        rules.put(FIELD2, null);
+        rules.put(FIELD2, new ProfileFieldRule(true, true, "field 2 should fail", Collections.emptySet()));
         fields.put("field3", "any value");
         try {
             ProfileValidationUtil.validate("profile-section", rules, fields);

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -238,6 +238,9 @@ public class ExporterTest {
 
     @Test
     public void testExportBeyondTheRepositoryBag() throws IOException {
+        final String bagConfigPath = "src/test/resources/configs/bagit-config-no-aptrust.yml";
+        final String bagProfileId = "BagIt-Profile-Identifier: http://fedora.info/bagprofile/beyondtherepository.json";
+
         final Config config = new Config();
         config.setMode("export");
         config.setBaseDirectory(exportDirectory);
@@ -246,7 +249,7 @@ public class ExporterTest {
         config.setRdfLanguage("application/ld+json");
         config.setResource(resource3);
         config.setBagProfile("beyondtherepository");
-        config.setBagConfigPath("src/test/resources/configs/bagit-config-no-aptrust.yml");
+        config.setBagConfigPath(bagConfigPath);
 
         final ExporterWrapper exporter = new ExporterWrapper(config, clientBuilder);
         when(headResponse.getLinkHeaders(eq("type"))).thenReturn(binaryLinks);
@@ -263,6 +266,7 @@ public class ExporterTest {
         Assert.assertTrue(bagInfoLines.contains("Bag-Size: 113 bytes"));
         Assert.assertTrue(bagInfoLines.contains("Payload-Oxum: 113.3"));
         Assert.assertTrue(bagInfoLines.contains("Source-Organization: My University"));
+        Assert.assertTrue(bagInfoLines.contains(bagProfileId));
     }
 
     @Test(expected = Exception.class)

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -193,7 +193,7 @@ public class ExporterTest {
     }
 
     @Test
-    public void testExportApTrustBag() throws Exception, FcrepoOperationFailedException {
+    public void testExportApTrustBag() throws Exception {
         final Config bagArgs = createAptrustBagConfig();
         bagArgs.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
 
@@ -234,6 +234,54 @@ public class ExporterTest {
         bagArgs.setResource(resource3);
         bagArgs.setBagProfile("aptrust");
         return bagArgs;
+    }
+
+    @Test
+    public void testExportBeyondBag() throws IOException {
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(exportDirectory);
+        config.setIncludeBinaries(true);
+        config.setPredicates(predicates);
+        config.setRdfLanguage("application/ld+json");
+        config.setResource(resource3);
+        config.setBagProfile("beyondtherepository");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config-no-aptrust.yml");
+
+        final ExporterWrapper exporter = new ExporterWrapper(config, clientBuilder);
+        when(headResponse.getLinkHeaders(eq("type"))).thenReturn(binaryLinks);
+        when(headResponse.getLinkHeaders(eq("describedby"))).thenReturn(describedbyLinks);
+        when(headResponse.getContentType()).thenReturn("image/tiff");
+        exporter.run();
+        Assert.assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/file1" + BINARY_EXTENSION)));
+        Assert.assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/file1/fcr%3Ametadata.jsonld")));
+        Assert.assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/alt_description.jsonld")));
+
+        final File baginfo = new File(exportDirectory + "/bag-info.txt");
+        Assert.assertTrue(baginfo.exists());
+        final List<String> baginfoLines = readLines(baginfo, UTF_8);
+        Assert.assertTrue(baginfoLines.contains("Bag-Size: 113 bytes"));
+        Assert.assertTrue(baginfoLines.contains("Payload-Oxum: 113.3"));
+        Assert.assertTrue(baginfoLines.contains("Source-Organization: My University"));
+    }
+
+    @Test(expected = Exception.class)
+    public void testExportBeyondBagValidationError() {
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(exportDirectory);
+        config.setIncludeBinaries(true);
+        config.setPredicates(predicates);
+        config.setRdfLanguage("application/ld+json");
+        config.setResource(resource3);
+        config.setBagProfile("beyondtherepository");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config-missing-source-org.yml");
+
+        final ExporterWrapper exporter = new ExporterWrapper(config, clientBuilder);
+        when(headResponse.getLinkHeaders(eq("type"))).thenReturn(binaryLinks);
+        when(headResponse.getLinkHeaders(eq("describedby"))).thenReturn(describedbyLinks);
+        when(headResponse.getContentType()).thenReturn("image/tiff");
+        exporter.run();
     }
 
     @Test

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -237,7 +237,7 @@ public class ExporterTest {
     }
 
     @Test
-    public void testExportBeyondBag() throws IOException {
+    public void testExportBeyondTheRepositoryBag() throws IOException {
         final Config config = new Config();
         config.setMode("export");
         config.setBaseDirectory(exportDirectory);
@@ -257,16 +257,16 @@ public class ExporterTest {
         Assert.assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/file1/fcr%3Ametadata.jsonld")));
         Assert.assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/alt_description.jsonld")));
 
-        final File baginfo = new File(exportDirectory + "/bag-info.txt");
-        Assert.assertTrue(baginfo.exists());
-        final List<String> baginfoLines = readLines(baginfo, UTF_8);
-        Assert.assertTrue(baginfoLines.contains("Bag-Size: 113 bytes"));
-        Assert.assertTrue(baginfoLines.contains("Payload-Oxum: 113.3"));
-        Assert.assertTrue(baginfoLines.contains("Source-Organization: My University"));
+        final File bagInfo = new File(exportDirectory + "/bag-info.txt");
+        Assert.assertTrue(bagInfo.exists());
+        final List<String> bagInfoLines = readLines(bagInfo, UTF_8);
+        Assert.assertTrue(bagInfoLines.contains("Bag-Size: 113 bytes"));
+        Assert.assertTrue(bagInfoLines.contains("Payload-Oxum: 113.3"));
+        Assert.assertTrue(bagInfoLines.contains("Source-Organization: My University"));
     }
 
     @Test(expected = Exception.class)
-    public void testExportBeyondBagValidationError() {
+    public void testExportBeyondTheRepositoryBagValidationError() {
         final Config config = new Config();
         config.setMode("export");
         config.setBaseDirectory(exportDirectory);

--- a/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
@@ -120,7 +120,7 @@ public class BagItIT extends AbstractResourceIT {
         final Path target = Paths.get(TARGET_DIR, exampleID);
         final Path bagInfo = target.resolve("bag-info.txt");
         assertTrue(bagInfo.toFile().exists());
-        List<String> bagInfoLines = Files.readAllLines(bagInfo);
+        final List<String> bagInfoLines = Files.readAllLines(bagInfo);
         assertTrue(bagInfoLines.contains("BagIt-Profile-Identifier: http://fedora.info/bagprofile/default.json"));
     }
 
@@ -133,20 +133,21 @@ public class BagItIT extends AbstractResourceIT {
         final Path bagInfo = target.resolve("bag-info.txt");
         assertTrue(bagInfo.toFile().exists());
         assertTrue(target.resolve("aptrust-info.txt").toFile().exists());
-        List<String> bagInfoLines = Files.readAllLines(bagInfo);
+        final List<String> bagInfoLines = Files.readAllLines(bagInfo);
         assertTrue(bagInfoLines.contains("BagIt-Profile-Identifier: http://fedora.info/bagprofile/aptrust.json"));
     }
 
     @Test
     public void testExportBeyondTheRepository() throws Exception {
         final String exampleID = UUID.randomUUID().toString();
+        final String bagProfileId = "BagIt-Profile-Identifier: http://fedora.info/bagprofile/beyondtherepository.json";
         runExportBag(exampleID, btrProfile, btrConfig);
 
         final Path target = Paths.get(TARGET_DIR, exampleID);
         final Path bagInfo = target.resolve("bag-info.txt");
         assertTrue(bagInfo.toFile().exists());
-        List<String> bagInfoLines = Files.readAllLines(bagInfo);
-        assertTrue(bagInfoLines.contains("BagIt-Profile-Identifier: http://fedora.info/bagprofile/beyondtherepository.json"));
+        final List<String> bagInfoLines = Files.readAllLines(bagInfo);
+        assertTrue(bagInfoLines.contains(bagProfileId));
     }
 
     @Test
@@ -178,7 +179,7 @@ public class BagItIT extends AbstractResourceIT {
 
     @Test
     public void testImportBeyondTheRepositoryBag() throws FcrepoOperationFailedException {
-        final URI resourceURI = URI.create(serverAddress + "testBagImport");
+        final URI resourceURI = URI.create(serverAddress + "testBagBtRImport");
         final String bagPath = TARGET_DIR + "/test-classes/sample/bag";
 
         final Config config = new Config();
@@ -192,7 +193,8 @@ public class BagItIT extends AbstractResourceIT {
         config.setBagProfile(btrProfile);
         config.setLegacy(true);
 
-        // Resource doesn't exist
+        // Remove resource from any previously run ITs and verify it does not exist
+        removeAndReset(resourceURI);
         assertFalse(exists(resourceURI));
 
         final Importer importer = new Importer(config, clientBuilder);

--- a/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
@@ -114,7 +114,6 @@ public class BagItIT extends AbstractResourceIT {
 
     @Test
     public void testExportDefault() throws Exception {
-        // todo: read bag-info for BagIt-Profile-Identifier
         final String exampleID = UUID.randomUUID().toString();
         runExportBag(exampleID, DEFAULT_BAG_PROFILE, defaultConfig);
 
@@ -178,7 +177,7 @@ public class BagItIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testImportBtRBag() throws FcrepoOperationFailedException {
+    public void testImportBeyondTheRepositoryBag() throws FcrepoOperationFailedException {
         final URI resourceURI = URI.create(serverAddress + "testBagImport");
         final String bagPath = TARGET_DIR + "/test-classes/sample/bag";
 

--- a/src/test/resources/configs/bagit-config-missing-source-org.yml
+++ b/src/test/resources/configs/bagit-config-missing-source-org.yml
@@ -1,0 +1,10 @@
+bag-info.txt:
+  Organization-Address: 123 University Ave, University City, 99999
+  Contact-Name: My Name
+  Contact-Phone: +19999999999
+  Contact-Email: anyone@university.edu
+  External-Description: ???
+  External-Identifier: ???
+  Bag-Group-Identifier: ???
+  Internal-Sender-Identifier: ???
+  Internal-Sender-Description: ???

--- a/src/test/resources/sample/bag/data/fcrepo/rest/testBagBtRImport.ttl
+++ b/src/test/resources/sample/bag/data/fcrepo/rest/testBagBtRImport.ttl
@@ -1,0 +1,30 @@
+@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .
+@prefix image: <http://www.modeshape.org/images/1.0> .
+@prefix sv: <http://www.jcp.org/jcr/sv/1.0> .
+@prefix test: <info:fedora/test/> .
+@prefix nt: <http://www.jcp.org/jcr/nt/1.0> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .
+@prefix mode: <http://www.modeshape.org/1.0> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix jcr: <http://www.jcp.org/jcr/1.0> .
+@prefix ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema> .
+@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .
+@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix authz: <http://fedora.info/definitions/v4/authorization#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+
+<http://localhost:8080/fcrepo/rest/testBagBtRImport> a fedora:Container , fedora:Resource ;
+	fedora:lastModifiedBy "fedoraAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	fedora:createdBy "fedoraAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	fedora:created "2016-12-13T17:40:06.531Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	fedora:lastModified "2016-12-13T17:40:06.531Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	a ldp:RDFSource , ldp:Container ;
+	fedora:writable "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+	fedora:hasParent <http://localhost:8080/fcrepo/rest/> .

--- a/src/test/resources/sample/bag/manifest-sha1.txt
+++ b/src/test/resources/sample/bag/manifest-sha1.txt
@@ -3,3 +3,4 @@ c537ab534deef7493140106c2151eccf2a219b8e  data/fcrepo/rest/testBagImport.ttl
 da39a3ee5e6b4b0d3255bfef95601890afd80709  data/fcrepo/rest/image0.binary
 427b598d3b581cb23d5efe362a52aa43a24cfebb  data/fcrepo/rest/bad_image/fcr%3Ametadata.ttl
 c537ab534deef7493140106c2151eccf2a219b8e  data/fcrepo/rest/bad_image.binary
+9b040aa0ceca4cdff2069b46769dcf1f04214833  data/fcrepo/rest/testBagBtRImport.ttl


### PR DESCRIPTION
Partially resolves (imo): https://jira.lyrasis.org/browse/FCREPO-3176

This adds support for some of the newer additions in both the  [bagit-profiles-spec](https://bagit-profiles.github.io/bagit-profiles-specification/) and the [beyond the repository bagit profile](https://github.com/dpscollaborative/btr_bagit_profile/blob/master/btr-bagit-profile.json):

* BagIt-Profile-Identifier is now written to the bag-info.txt
  * BagIt-Profile-Version is not, but it looks it will be required for validation of v1.2.0 (though currently this passes validation using the [bagit-profiles-validator](https://github.com/bagit-profiles/bagit-profiles-validator))
* Bag-Info now supports the `repeatable` and `description` options
  * `recommended` was also added from the beyond the repository spec; a warning is logged on any missing recommended fields
  * currently it is not possible to have repeated values in the bagit configs, so it is there only for completion
* Tag-Files-Allowed is checked against when validating a BagConfig

I also opted to read in the full bag profile json in BagProfile in anticipation of doing more validation against BagIt Bags, as I think there's some additional opportunity for both the BagIt Profiles and import of BagIt Bags. 

For the BagIt Profiles, you'll find requirements mentioned throughout the spec such as:
> Every file in Tag-Files-Required must also be present in Tag-Files-Allowed. 

This I haven't added yet but could be done either when reading the BagIt Profile json or with the BagConfig validation.

For the Import, it looks like work had been started for validating BagIt Bags before running the Import process itself but had been put on hold. I don't think would be onerous to add support for ensuring a Bag conforms to a profile, but I wanted to keep this PR scoped to export.
