### PR TITLE
Export SHA-512 For BagIt Bags

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/BagWriter.java
+++ b/src/main/java/org/fcrepo/importexport/common/BagWriter.java
@@ -155,6 +155,7 @@ public class BagWriter {
             MessageDigest md5 = null;
             MessageDigest sha1 = null;
             MessageDigest sha256 = null;
+            MessageDigest sha512 = null;
             if (algorithms.contains("md5")) {
                 md5 = MessageDigest.getInstance("MD5");
             }
@@ -163,6 +164,9 @@ public class BagWriter {
             }
             if (algorithms.contains("sha256")) {
                 sha256 = MessageDigest.getInstance("SHA-256");
+            }
+            if (algorithms.contains("sha512")) {
+                sha512 = MessageDigest.getInstance("SHA-512");
             }
 
             try (OutputStream out = new FileOutputStream(f)) {
@@ -180,12 +184,16 @@ public class BagWriter {
                     if (sha256 != null) {
                         sha256.update(bytes);
                     }
+                    if (sha512 != null) {
+                        sha512.update(bytes);
+                    }
                 }
             }
 
             addTagChecksum("md5", f, md5);
             addTagChecksum("sha1", f, sha1);
             addTagChecksum("sha256", f, sha256);
+            addTagChecksum("sha512", f, sha512);
         }
     }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -115,9 +115,11 @@ public class Exporter implements TransferProcess {
     private String bagProfileId;
     private MessageDigest sha1 = null;
     private MessageDigest sha256 = null;
+    private MessageDigest sha512 = null;
     private MessageDigest md5 = null;
     private HashMap<File, String> sha1FileMap = null;
     private HashMap<File, String> sha256FileMap = null;
+    private HashMap<File, String> sha512FileMap = null;
     private HashMap<File, String> md5FileMap = null;
 
     private Logger exportLogger;
@@ -164,6 +166,11 @@ public class Exporter implements TransferProcess {
                     this.sha256FileMap = new HashMap<>();
                     this.sha256 = MessageDigest.getInstance("SHA-256");
                     algorithms.add("sha256");
+                }
+                if (bagProfile.getPayloadDigestAlgorithms().contains("sha512")) {
+                    this.sha512FileMap = new HashMap<>();
+                    this.sha512 = MessageDigest.getInstance("SHA-512");
+                    algorithms.add("sha512");
                 }
 
                 //enforce default metadata
@@ -242,6 +249,9 @@ public class Exporter implements TransferProcess {
                 bag.registerChecksums("sha1", sha1FileMap);
                 if (sha256 != null) {
                     bag.registerChecksums("sha256", sha256FileMap);
+                }
+                if (sha512 != null) {
+                    bag.registerChecksums("sha512", sha512FileMap);
                 }
                 if (md5 != null) {
                     bag.registerChecksums("md5", md5FileMap);
@@ -585,6 +595,9 @@ public class Exporter implements TransferProcess {
             if (sha256FileMap != null) {
                 sha256FileMap.put(file, new String(encodeHex(sha256.digest())));
             }
+            if (sha512FileMap != null) {
+                sha512FileMap.put(file, new String(encodeHex(sha512.digest())));
+            }
         }
 
         if (describedby != null) {
@@ -610,6 +623,9 @@ public class Exporter implements TransferProcess {
         if (sha256 != null) {
             sha256.reset();
         }
+        if (sha512 != null) {
+            sha512.reset();
+        }
 
         int read = 0;
         final byte[] buf = new byte[8192];
@@ -622,6 +638,9 @@ public class Exporter implements TransferProcess {
             }
             if (sha256 != null) {
                 sha256.update(buf, 0, read);
+            }
+            if (sha512 != null) {
+                sha512.update(buf, 0, read);
             }
             if (out != null) {
                 out.write(buf, 0, read);

--- a/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
+++ b/src/test/java/org/fcrepo/importexport/common/BagProfileTest.java
@@ -41,10 +41,12 @@ public class BagProfileTest {
         assertTrue(profile.getPayloadDigestAlgorithms().contains("md5"));
         assertTrue(profile.getPayloadDigestAlgorithms().contains("sha1"));
         assertTrue(profile.getPayloadDigestAlgorithms().contains("sha256"));
+        assertTrue(profile.getPayloadDigestAlgorithms().contains("sha512"));
 
         assertFalse(profile.getTagDigestAlgorithms().contains("md5"));
         assertTrue(profile.getTagDigestAlgorithms().contains("sha1"));
-        assertFalse(profile.getTagDigestAlgorithms().contains("sha256"));
+        assertTrue(profile.getTagDigestAlgorithms().contains("sha256"));
+        assertTrue(profile.getTagDigestAlgorithms().contains("sha512"));
 
         assertTrue(profile.getMetadataFields().get("Source-Organization").isRequired());
         assertTrue(profile.getMetadataFields().get("Organization-Address").isRequired());

--- a/src/test/resources/profiles/profile.json
+++ b/src/test/resources/profiles/profile.json
@@ -52,12 +52,12 @@
       }
    },
    "Manifests-Required":[
-      "md5", "sha1", "sha256"
+      "md5", "sha1", "sha256", "sha512"
    ],
    "Allow-Fetch.txt":false,
    "Serialization":"optional",
    "Tag-Manifests-Required":[
-     "sha1"
+     "sha1", "sha256", "sha512"
    ],
    "Accept-BagIt-Version":[
       "0.97"


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3207

* Allows sha512 manifests to be written by the Exporter when specified in a bag profile