### PR TITLE
Resolve Import hanging after completion

### DIFF
--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -882,12 +882,11 @@ public class Importer implements TransferProcess {
      * @return the {@link Bag} if valid
      */
     private Bag verifyBag(final Path bagDir, final BagProfile profile) {
-        try {
+        try (BagVerifier bagVerifier = new BagVerifier()) {
             final BagReader bagReader = new BagReader();
             final Bag bag = bagReader.read(bagDir);
             profile.validateBag(bag);
 
-            final BagVerifier bagVerifier = new BagVerifier();
             bagVerifier.isValid(bag, false);
 
             return bag;


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3361

* Wrap BagVerifier using try-with-resources in order to close its resources

-----------------------------

# Testing

1. Start a fresh fedora repository, e.g. with fcrepo4-docker `FEDORA_TAG=5.1.0 docker-compose up -d`
2. Create a binary in the repository
3. Create a bag-config.yml for export
```
bag-info.txt:
  Source-Organization: fcrepo-import-export
  Organization-Address: localhost
  External-Description: BagIt Bag
```
4. Run the exporter
```
java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode export --resource http://localhost:8080/fcrepo/rest --dir fcrepo-3361  --binaries --bag-profile beyondtherepository --bag-config bag-config.yml --user fedoraAdmin:secret3
```
5. Run the import and see the process no longer hang after completion
```
java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode import --resource http://localhost:8080/fcrepo/rest --dir fcrepo-3361  --binaries --bag-profile beyondtherepository --bag-config bag-config.yml --user fedoraAdmin:secret3
```