### PR TITLE
Import bags when the directory is prefixed with '.'

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -25,6 +25,7 @@ import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +109,7 @@ public class Config {
      * @param directory to export to or import from
      */
     public void setBaseDirectory(final String directory) {
-        this.baseDirectory = directory == null ? null : new File(directory);
+        this.baseDirectory = directory == null ? null : Paths.get(directory).normalize().toFile();
     }
 
     /**

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -185,7 +185,9 @@ public class Importer implements TransferProcess {
                 profile = new BagProfile(BagProfile.BuiltIn.from(config.getBagProfile()));
             } catch (IllegalArgumentException ignored) {
                 // ok, we weren't given a profile identifier; try to initialize from a FileInputStream instead
-                profile = new BagProfile(Files.newInputStream(Paths.get(config.getBagProfile())));
+                try (InputStream profileIn = Files.newInputStream(Paths.get(config.getBagProfile()))) {
+                    profile = new BagProfile(profileIn);
+                }
             }
 
             final Path root;


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3386

* Normalize the directory path when setting 
* Close InputStream when loading custom BagProfile json

-------------------------------------------
# Testing

1. Start a fresh fedora repository, e.g. with fcrepo4-docker `FEDORA_TAG=5.1.0 docker-compose up -d`
2. Create a binary in the repository
3. Create a bag-config.yml for export
   ```
   bag-info.txt:
     Source-Organization: fcrepo-import-export
     Organization-Address: localhost
     External-Description: BagIt Bag
   ```
4. Run the exporter
   ```
   java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode export --resource http://localhost:8080/fcrepo/rest --dir fcrepo-3386  --binaries --bag-profile beyondtherepository --bag-config bag-config.yml --user fedoraAdmin:secret3
   ```
5. Run the import prefixing the directory with `./`
   ```
   java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode import --resource http://localhost:8080/fcrepo/rest --dir ./fcrepo-3386  --binaries --bag-profile beyondtherepository --bag-config bag-config.yml --user fedoraAdmin:secret3
   ```
   a. I also tested against `./fcrepo-3386.tar`, `../fcrepo-3386.tar`, and `../fcrepo-3386`. The Fedora repository was reset between each run to ensure the binaries were correctly uploaded by bringing down the docker container and starting a fresh version again.