### PR TITLE
CLI Argument for BagIt Hash Algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ To change the import-export logging level (default is INFO), set the `fcrepo.log
 $ java -Dfcrepo.log.importexport=WARN -jar target/fcrepo-import-export-<version>.jar --mode [import|export] [options]
 ```
 
+To provide a user and password for Fedora basic authentication, use the `-u` or `--user` argument, e.g.:
+```sh
+-u fedoraAdmin:secret3
+```
+
 To control the format of the exported RDF, the RDF language/serialization format can also be specified by adding, e.g.:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ following bag profiles:
 * [perseids](https://raw.githubusercontent.com/duraspace/bagit-support/master/src/main/resources/profiles/perseids.json)
 * [beyondtherepository](https://raw.githubusercontent.com/duraspace/bagit-support/master/src/main/resources/profiles/beyondtherepository.json)
 
+### BagIt Hash Algorithms
+
+Hash algorithms can be specified using the `--bag-algorithms` option. The algorithms specified must be separated by a 
+`,` and must be supported by the bag profile. If an algorithm is specified as required by the bag profile, it will 
+automatically be included when exporting a bag.
+
 ### BagIt Metadata
 
 User supplied metadata for tag files can be provided with a Yaml file specified by the `-G` or `--bag-config` option.
@@ -207,7 +213,7 @@ bag-info.txt:
 
 Execute the import-export-utility:
 ```sh
-java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/example_bag --binaries --bag-profile default --bag-serialization tar --bag-config /tmp/bagit-config.yml
+java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/example_bag --binaries --bag-profile default --bag-serialization tar --bag-config /tmp/bagit-config.yml --bag-algorithms sha1 -u fedoraAdmin:secret3
 ```
 
 #### Export using the APTrust profile with user supplied metadata
@@ -233,7 +239,7 @@ aptrust-info.txt:
 
 Execute the import-export-utility:
 ```sh
-java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/example_bag --binaries --bag-profile aptrust --bag-config /tmp/bagit-config.yml
+java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/example_bag --binaries --bag-profile aptrust --bag-config /tmp/bagit-config.yml --bag-algorithms md5,sha256 -u fedoraAdmin:secret3
 ```
 
 Additional tag files can be created by adding top-level keys in the user supplied Yaml file like the `aptrust-info.txt` added in the `bagit-config-aptrust.yml` example.

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -199,6 +199,12 @@ public class ArgParser {
                 .desc("Path to the bag config file")
                 .build());
 
+        configOptions.addOption(Option.builder()
+                .longOpt("bag-algorithms").argName("algorithms")
+                .hasArgs().valueSeparator(',')
+                .required(false)
+                .desc("Comma separated list of algorithms to use when creating a BagIt export")
+                .build());
 
         // create the description for the serialization option
         // this shows which options are available for each of the built in BagProfiles
@@ -429,6 +435,7 @@ public class ArgParser {
         config.setBagProfile(cmd.getOptionValue('g'));
         config.setBagConfigPath(cmd.getOptionValue('G'));
         config.setBagSerialization(cmd.getOptionValue('s'));
+        config.setBagAlgorithms(cmd.getOptionValues("bag-algorithms"));
 
         config.setAuditLog(cmd.hasOption('a'));
 
@@ -583,6 +590,10 @@ public class ArgParser {
                 c.setBagProfile(entry.getValue().toLowerCase());
             } else if (entry.getKey().equalsIgnoreCase(BAG_CONFIG_OPTION_KEY)) {
                 c.setBagConfigPath(entry.getValue().toLowerCase());
+            } else if (entry.getKey().trim().equalsIgnoreCase("algorithm")) {
+                c.setBagAlgorithms(entry.getValue().split(","));
+            } else if (entry.getKey().trim().equalsIgnoreCase("serialization")) {
+                c.setBagSerialization(entry.getValue());
             } else if (entry.getKey().equalsIgnoreCase("predicates")) {
                 c.setPredicates(entry.getValue().split(","));
             } else if (entry.getKey().equalsIgnoreCase("auditLog")) {

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -186,7 +186,7 @@ public class ArgParser {
         // bagit creation
         configOptions.addOption(Option.builder("g")
                 .longOpt(BAG_PROFILE_OPTION_KEY).argName("profile")
-                .hasArg(true).numberOfArgs(1).argName("profile")
+                .hasArg(true).numberOfArgs(1)
                 .required(false)
                 .desc("Export and import BagIt bags using profile [default|aptrust|metaarchive|perseids|\n" +
                       "beyondtherepository]")
@@ -194,7 +194,7 @@ public class ArgParser {
 
         configOptions.addOption(Option.builder("G")
                 .longOpt(BAG_CONFIG_OPTION_KEY).argName("path")
-                .hasArg(true).numberOfArgs(1).argName("path")
+                .hasArg(true).numberOfArgs(1)
                 .required(false)
                 .desc("Path to the bag config file")
                 .build());
@@ -235,15 +235,15 @@ public class ArgParser {
             }
         }
         configOptions.addOption(Option.builder("s")
-                               .longOpt("bag-serialization").argName("format")
-                               .hasArg(true).numberOfArgs(1).argName("format")
-                               .required(false)
-                               .desc(serializationDesc.toString())
-                               .build());
+                .longOpt("bag-serialization").argName("format")
+                .hasArg(true).numberOfArgs(1)
+                .required(false)
+                .desc(serializationDesc.toString())
+                .build());
 
         configOptions.addOption(Option.builder("R")
                 .longOpt("repositoryRoot").argName("uri")
-                .hasArg(true).numberOfArgs(1).argName("uri")
+                .hasArg(true).numberOfArgs(1)
                 .required(false)
                 .desc("When exporting, use this URI as the repository root; " +
                         "if not given, export will attempt to automatically determine the repository root")

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -67,6 +67,7 @@ public class Config {
     private String bagProfile = null;
     private String bagConfigPath = null;
     private String bagSerialization = null;
+    private String[] bagAlgorithms = null;
 
     private String[] predicates = DEFAULT_PREDICATES;
     private String rdfExtension = DEFAULT_RDF_EXT;
@@ -393,6 +394,23 @@ public class Config {
     }
 
     /**
+     * Set the BagIt algorithms to use during export
+     * @param bagAlgorithms An array of algorithms
+     */
+    public void setBagAlgorithms(final String[] bagAlgorithms) {
+        this.bagAlgorithms = bagAlgorithms;
+    }
+
+    /**
+     * Gets the user specified algorithms to use when bagging
+     *
+     * @return the algorithms, or null if not specified
+     */
+    public String[] getBagAlgorithms() {
+        return bagAlgorithms;
+    }
+
+    /**
      * Sets the RDF filename extension
      *
      * @param extension of the RDF filename
@@ -533,7 +551,13 @@ public class Config {
         if (this.getBagConfigPath() != null) {
             map.put("bag-config", this.getBagConfigPath());
         }
-        final String predicates = Arrays.stream(this.getPredicates()).collect(Collectors.joining(","));
+        if (this.getBagSerialization() != null) {
+            map.put("bag-serialization", this.getBagSerialization());
+        }
+        if (this.getBagAlgorithms() != null) {
+            map.put("bag-algorithms", String.join(",", this.getBagAlgorithms()));
+        }
+        final String predicates = String.join(",", this.getPredicates());
         map.put("predicates", predicates);
         map.put("auditLog", Boolean.toString(this.auditLog));
         return map;

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -26,10 +26,8 @@ import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.jena.riot.Lang;
 import org.slf4j.Logger;

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -259,7 +259,7 @@ public class Exporter implements TransferProcess {
                 this.sha512FileMap = new HashMap<>();
                 break;
             default:
-                throw new IllegalStateException("Unexpected value: " + digest);
+                throw new IllegalStateException("Unexpected BagIt algorithm: " + digest);
         }
     }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -200,7 +200,7 @@ public class Exporter implements TransferProcess {
      * @param profile the profile to get BagItDigests for
      * @return the algorithms which were initialized, as {@link BagItDigest}s
      */
-    public Set<BagItDigest> setupBagItDigests(final BagProfile profile) {
+    private Set<BagItDigest> setupBagItDigests(final BagProfile profile) {
         final Set<String> algorithms = new HashSet<>();
         final Set<String> allowedAlgorithms = profile.getAllowedPayloadAlgorithms();
         final Set<String> requiredAlgorithms = profile.getPayloadDigestAlgorithms();
@@ -224,7 +224,7 @@ public class Exporter implements TransferProcess {
         // check if we should fallback to the allowed algorithms or sha1
         if (algorithms.isEmpty() && !allowedAlgorithms.isEmpty()) {
             algorithms.addAll(allowedAlgorithms);
-        } else {
+        } else if (algorithms.isEmpty()) {
             algorithms.add("SHA1");
         }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -55,7 +55,6 @@ import java.security.MessageDigest;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -64,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
@@ -161,20 +161,8 @@ public class Exporter implements TransferProcess {
                 bagProfile = new BagProfile(Files.newInputStream(Paths.get(config.getBagProfile())));
             }
 
-            final Set<BagItDigest> algorithms;
-            // set up algorithms to use based on the required algorithms
-            // if none are found, use the allowed algorithms
-            // if the algorithms are still empty, use sha1
-            if (!bagProfile.getPayloadDigestAlgorithms().isEmpty()) {
-                algorithms = setupFileMap(bagProfile.getPayloadDigestAlgorithms());
-            } else if (!bagProfile.getAllowedPayloadAlgorithms().isEmpty()) {
-                algorithms = setupFileMap(bagProfile.getAllowedPayloadAlgorithms());
-            } else {
-                final BagItDigest sha1 = BagItDigest.SHA1;
-                this.sha1FileMap = new HashMap<>();
-                this.sha1 = sha1.messageDigest();
-                algorithms = Collections.singleton(sha1);
-            }
+            // configure the BagIt algorithms to use + setup the fields for the Exporter
+            final Set<BagItDigest> algorithms = setupBagItDigests(bagProfile);
 
             //enforce default metadata
             bagProfile.validateConfig(bagConfig);
@@ -204,41 +192,75 @@ public class Exporter implements TransferProcess {
     }
 
     /**
-     * Configure the digest algorithms and fileMaps given a Set of algorithm names
+     * Set up the hash algorithms (as {@link BagItDigest}) to use based on the {@link Config} and {@link BagProfile}
+     * Always use the user specified + profile required algorithms
+     * If neither is specified, use the profile "manifest-allowed" and "tag-manifest-allowed"
+     * If the algorithms are still empty, use sha1
      *
-     * @param algorithms the algorithms to initialize fields for
+     * @param profile the profile to get BagItDigests for
      * @return the algorithms which were initialized, as {@link BagItDigest}s
      */
-    private Set<BagItDigest> setupFileMap(final Set<String> algorithms) {
-        final BagItDigest md5 = BagItDigest.MD5;
-        final BagItDigest sha1 = BagItDigest.SHA1;
-        final BagItDigest sha256 = BagItDigest.SHA256;
-        final BagItDigest sha512 = BagItDigest.SHA512;
-        final HashSet<BagItDigest> bagItDigests = new HashSet<>();
+    public Set<BagItDigest> setupBagItDigests(final BagProfile profile) {
+        final Set<String> algorithms = new HashSet<>();
+        final Set<String> allowedAlgorithms = profile.getAllowedPayloadAlgorithms();
+        final Set<String> requiredAlgorithms = profile.getPayloadDigestAlgorithms();
 
-        for (String algorithm : algorithms) {
-            if (algorithm.equalsIgnoreCase(md5.bagitName())) {
-                this.md5 = md5.messageDigest();
-                this.md5FileMap = new HashMap<>();
-                bagItDigests.add(md5);
-            } else if (algorithm.equalsIgnoreCase(sha1.bagitName())) {
-                this.sha1 = sha1.messageDigest();
-                this.sha1FileMap = new HashMap<>();
-                bagItDigests.add(sha1);
-            } else if (algorithm.equalsIgnoreCase(sha256.bagitName())) {
-                this.sha256 = sha256.messageDigest();
-                this.sha256FileMap = new HashMap<>();
-                bagItDigests.add(sha256);
-            } else if (algorithm.equalsIgnoreCase(sha512.bagitName())) {
-                this.sha512 = sha512.messageDigest();
-                this.sha512FileMap = new HashMap<>();
-                bagItDigests.add(sha512);
-            } else {
-                logger.warn("Unsupported BagIt digest algorithm! {}", algorithm);
+        // first validate that the profile supports user specified algorithms
+        final String[] userAlgorithms = config.getBagAlgorithms();
+        if (userAlgorithms != null) {
+            for (String algorithm : userAlgorithms) {
+                if (!allowedAlgorithms.isEmpty() && !allowedAlgorithms.contains(algorithm)) {
+                    throw new RuntimeException("Bag Profile does not allow specified algorithm: " + algorithm +
+                                               ". Allowed algorithms are: " + allowedAlgorithms);
+                }
+
+                algorithms.add(algorithm);
             }
         }
 
-        return bagItDigests;
+        // always add required algorithms
+        algorithms.addAll(requiredAlgorithms);
+
+        // check if we should fallback to the allowed algorithms or sha1
+        if (algorithms.isEmpty() && !allowedAlgorithms.isEmpty()) {
+            algorithms.addAll(allowedAlgorithms);
+        } else {
+            algorithms.add("SHA1");
+        }
+
+        return algorithms.stream()
+                             .map(String::toUpperCase)
+                             .map(BagItDigest::valueOf)
+                             .peek(this::setupFileMap)
+                             .collect(Collectors.toSet());
+    }
+
+    /**
+     * Configure the digest algorithm and fileMap for a given BagItDigest
+     *
+     * @param digest the BagItDigest to initialize fields for
+     */
+    private void setupFileMap(final BagItDigest digest) {
+        switch (digest) {
+            case MD5:
+                this.md5 = digest.messageDigest();
+                this.md5FileMap = new HashMap<>();
+                break;
+            case SHA1:
+                this.sha1 = digest.messageDigest();
+                this.sha1FileMap = new HashMap<>();
+                break;
+            case SHA256:
+                this.sha256 = digest.messageDigest();
+                this.sha256FileMap = new HashMap<>();
+                break;
+            case SHA512:
+                this.sha512 = digest.messageDigest();
+                this.sha512FileMap = new HashMap<>();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + digest);
+        }
     }
 
     /**
@@ -297,8 +319,8 @@ public class Exporter implements TransferProcess {
                 bag.write();
 
                 if (bagSerializer != null) {
-                    // Make sure the path is an absolute path because the BagSerializer uses relativize which requires
-                    // both Paths to be of the same type
+                    // Make sure the path is an absolute path because the BagSerializer uses Path#relativize which
+                    // requires both Paths to be of the same type
                     bagSerializer.serialize(bag.getRootDir().getAbsoluteFile().toPath());
                 }
             } catch (IOException e) {
@@ -307,8 +329,7 @@ public class Exporter implements TransferProcess {
                 e.printStackTrace();
             }
         }
-        exportLogger.info("Finished export... {} bytes/{} resources exported", successBytes.get(),
-                successCount.get());
+        exportLogger.info("Finished export... {} bytes/{} resources exported", successBytes.get(), successCount.get());
     }
 
     private Map<String, String> bagTechMetadata() {

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -225,7 +225,7 @@ public class Exporter implements TransferProcess {
         if (algorithms.isEmpty() && !allowedAlgorithms.isEmpty()) {
             algorithms.addAll(allowedAlgorithms);
         } else if (algorithms.isEmpty()) {
-            algorithms.add("SHA1");
+            algorithms.add(BagItDigest.SHA1.bagitName());
         }
 
         return algorithms.stream()

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -164,11 +165,12 @@ public class ArgParserTest {
     @Test
     public void parseBagProfile() throws Exception {
         final Config config = parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS,
-                "-g", "default", "-G", "path/config.yaml", "-s", "zip" ));
+                "-g", "default", "-G", "path/config.yaml", "-s", "zip", "--bag-algorithms", "md5,sha1" ));
         Assert.assertEquals("zip", config.getBagSerialization());
         Assert.assertEquals("default", config.getBagProfile());
         Assert.assertEquals(new File("/tmp/rdf/data"), config.getBaseDirectory());
         Assert.assertEquals("path/config.yaml", config.getBagConfigPath());
+        Assert.assertArrayEquals(new String[]{"md5", "sha1"}, config.getBagAlgorithms());
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -52,6 +52,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.duraspace.bagit.BagItDigest;
 import org.duraspace.bagit.BagProfile;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
@@ -231,6 +232,7 @@ public class ExporterTest {
     @Test
     public void testExportApTrustBag() throws Exception {
         final Config bagArgs = createAptrustBagConfig();
+        bagArgs.setBagAlgorithms(new String[]{BagItDigest.SHA256.bagitName()});
         bagArgs.setBagSerialization("tar");
         bagArgs.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
 
@@ -239,6 +241,8 @@ public class ExporterTest {
         when(headResponse.getLinkHeaders(eq("describedby"))).thenReturn(describedbyLinks);
         when(headResponse.getContentType()).thenReturn("image/tiff");
         exporter.run();
+        assertTrue(Files.exists(Paths.get(exportDirectory, "manifest-md5.txt")));
+        assertTrue(Files.exists(Paths.get(exportDirectory, "manifest-sha256.txt")));
         assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/file1" + BINARY_EXTENSION)));
         assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/file1/fcr%3Ametadata.jsonld")));
         assertTrue(exporter.wroteFile(new File(exportDirectory + "/data/rest/alt_description.jsonld")));

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -270,9 +270,19 @@ public class ExporterTest {
     }
 
     @Test(expected = Exception.class)
-    public void testExportApTrustBagValidationError() throws Exception, FcrepoOperationFailedException {
+    public void testExportApTrustBagValidationError() {
         final Config bagArgs = createAptrustBagConfig();
         bagArgs.setBagConfigPath("src/test/resources/configs/bagit-config-missing-access.yml");
+        final ExporterWrapper exporter = new ExporterWrapper(bagArgs, clientBuilder);
+        exporter.run();
+    }
+
+    @Test(expected = Exception.class)
+    public void testExportApTrustBagInvalidUserAlgorithm() {
+        final Config bagArgs = createAptrustBagConfig();
+        bagArgs.setBagAlgorithms(new String[]{BagItDigest.SHA1.bagitName()});
+        bagArgs.setBagSerialization("tar");
+        bagArgs.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
         final ExporterWrapper exporter = new ExporterWrapper(bagArgs, clientBuilder);
         exporter.run();
     }


### PR DESCRIPTION
Resolves: [https://jira.lyrasis.org/browse/FCREPO-3366 ](https://jira.lyrasis.org/browse/FCREPO-3366 )

* Adds `--bag-algorithms` to allow user specified hash algorithms when bagging

----------------------------------------
# Notes

I didn't add a short option, but could if a good letter can be chosen (a, d, h are taken -- maybe capitalizing one is the way to go).

----------------------------------------
# Testing

1. Start a fresh fedora repository, e.g. with fcrepo4-docker `FEDORA_TAG=5.1.0 docker-compose up -d`
2. Create a binary in the repository
3. Create a bag-config.yml for export
   ```
   bag-info.txt:
     Source-Organization: fcrepo-import-export
     Organization-Address: localhost
     External-Description: BagIt Bag
   ```
4. Run the exporter, specifying the hash algorithms you want to use
   ```
   java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode export --resource http://localhost:8080/fcrepo/rest --dir fcrepo-3366  --binaries --bag-profile beyondtherepository --bag-config bag-config.yml --bag-algorithms sha1,sha256 --user fedoraAdmin:secret3
   ```
5. Check the exported bag only has the algorithms specified